### PR TITLE
Initialize Yubikey Escape Room

### DIFF
--- a/assets/css/escape-room.css
+++ b/assets/css/escape-room.css
@@ -1,0 +1,679 @@
+/* ============================================================
+   CERBERUS ESCAPE ROOM — STYLESHEET
+   Terminal / hacker aesthetic. Designed for iPad fullscreen.
+   ============================================================ */
+
+/* ---- Reset & base ---------------------------------------- */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --green:       #00ff41;
+  --green-dim:   #00cc33;
+  --green-dark:  #003310;
+  --red:         #ff2222;
+  --red-dim:     #cc0000;
+  --red-dark:    #1a0000;
+  --amber:       #ffaa00;
+  --amber-dim:   #cc8800;
+  --blue:        #00aaff;
+  --white:       #e8ffe8;
+  --gray:        #4a4a4a;
+  --bg:          #020c02;
+  --font-mono:   "Courier New", "Courier", monospace;
+  --border:      1px solid var(--green-dim);
+}
+
+html, body {
+  width: 100%;
+  height: 100%;
+  background: var(--bg);
+  color: var(--green);
+  font-family: var(--font-mono);
+  font-size: 16px;
+  line-height: 1.5;
+  overflow: hidden;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* ---- Scanline overlay ------------------------------------ */
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0px,
+    transparent 3px,
+    rgba(0,0,0,0.03) 3px,
+    rgba(0,0,0,0.03) 4px
+  );
+  pointer-events: none;
+  z-index: 9999;
+}
+
+/* ---- Screen container ------------------------------------ */
+.screen {
+  display: none;
+  position: absolute;
+  inset: 0;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 40px;
+  text-align: center;
+  animation: fadeIn 0.4s ease;
+}
+.screen.active {
+  display: flex;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ---- Global HUD (timer + stage) -------------------------- */
+#hud {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  display: none;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 20px;
+  background: rgba(0,0,0,0.85);
+  border-bottom: var(--border);
+  z-index: 100;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+}
+#hud.visible { display: flex; }
+
+#hud-stage { color: var(--green-dim); }
+#hud-timer {
+  font-size: 20px;
+  font-weight: bold;
+  color: var(--green);
+  letter-spacing: 0.1em;
+  transition: color 0.3s;
+}
+#hud-timer.warning { color: var(--amber); animation: timerPulse 1s infinite; }
+#hud-timer.danger  { color: var(--red);   animation: timerPulse 0.5s infinite; }
+
+@keyframes timerPulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.4; }
+}
+
+/* ---- HUD clearance (prevent fixed bar from covering content) */
+#hud.visible ~ .screen.active {
+  padding-top: 52px;
+}
+
+/* ---- Logo / title ---------------------------------------- */
+.cerberus-logo {
+  font-size: clamp(22px, 4vw, 36px);
+  font-weight: bold;
+  letter-spacing: 0.25em;
+  color: var(--green);
+  text-shadow: 0 0 16px var(--green), 0 0 32px var(--green-dim);
+  margin-bottom: 6px;
+}
+.cerberus-sub {
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  color: var(--green-dim);
+  margin-bottom: 32px;
+}
+
+/* ---- Intro screen ---------------------------------------- */
+#screen-intro .intro-box {
+  max-width: 560px;
+  border: var(--border);
+  border-radius: 4px;
+  padding: 28px 32px;
+  background: rgba(0,255,65,0.03);
+  text-align: left;
+  margin-bottom: 28px;
+}
+.intro-box p {
+  color: var(--white);
+  margin-bottom: 12px;
+  font-size: 15px;
+  line-height: 1.7;
+}
+.intro-box p:last-child { margin-bottom: 0; }
+.intro-box strong { color: var(--amber); }
+
+/* ---- Buttons --------------------------------------------- */
+.btn {
+  display: inline-block;
+  padding: 12px 32px;
+  border: 2px solid var(--green);
+  border-radius: 2px;
+  background: transparent;
+  color: var(--green);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  letter-spacing: 0.15em;
+  cursor: pointer;
+  text-transform: uppercase;
+  transition: background 0.15s, color 0.15s, box-shadow 0.15s;
+}
+.btn:hover, .btn:focus {
+  background: var(--green);
+  color: var(--bg);
+  box-shadow: 0 0 20px var(--green);
+  outline: none;
+}
+.btn-red {
+  border-color: var(--red);
+  color: var(--red);
+}
+.btn-red:hover, .btn-red:focus {
+  background: var(--red);
+  color: var(--bg);
+  box-shadow: 0 0 20px var(--red);
+}
+.btn-amber {
+  border-color: var(--amber);
+  color: var(--amber);
+}
+.btn-amber:hover, .btn-amber:focus {
+  background: var(--amber);
+  color: var(--bg);
+  box-shadow: 0 0 20px var(--amber);
+}
+
+/* ---- Stage 0: Login screen ------------------------------- */
+#screen-stage0 {
+  background: #0a0a14;
+}
+.login-panel {
+  width: 360px;
+  border: 1px solid #334;
+  border-radius: 6px;
+  padding: 36px 32px;
+  background: #0e0e1c;
+  box-shadow: 0 8px 48px rgba(0,0,0,0.8);
+}
+.login-logo {
+  font-size: 22px;
+  letter-spacing: 0.2em;
+  color: #99aaff;
+  text-align: center;
+  margin-bottom: 6px;
+}
+.login-tagline {
+  font-size: 10px;
+  letter-spacing: 0.25em;
+  color: #445;
+  text-align: center;
+  margin-bottom: 28px;
+}
+.login-field {
+  margin-bottom: 16px;
+}
+.login-field label {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  color: #778;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+}
+.login-field input {
+  width: 100%;
+  padding: 10px 12px;
+  background: #12121e;
+  border: 1px solid #334;
+  border-radius: 3px;
+  color: #ccd;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.2s;
+}
+.login-field input:focus {
+  border-color: #7788ff;
+}
+.login-submit {
+  width: 100%;
+  padding: 11px;
+  margin-top: 8px;
+  background: #3344cc;
+  border: none;
+  border-radius: 3px;
+  color: #eef;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.login-submit:hover { background: #4455dd; }
+.login-error {
+  margin-top: 12px;
+  font-size: 12px;
+  color: #ff4455;
+  text-align: center;
+  min-height: 18px;
+}
+
+/* ---- Alert / lockdown screen ----------------------------- */
+#screen-lockdown {
+  background: var(--red-dark);
+}
+.lockdown-alert {
+  animation: alertFlash 0.8s ease 3;
+}
+@keyframes alertFlash {
+  0%, 100% { background: var(--red-dark); }
+  50%       { background: #3a0000; }
+}
+.alert-icon {
+  font-size: 64px;
+  margin-bottom: 16px;
+  animation: shake 0.4s ease 0s 3;
+}
+@keyframes shake {
+  0%,100% { transform: translateX(0); }
+  25%     { transform: translateX(-8px); }
+  75%     { transform: translateX(8px); }
+}
+.alert-title {
+  font-size: clamp(24px, 5vw, 42px);
+  font-weight: bold;
+  color: var(--red);
+  letter-spacing: 0.2em;
+  text-shadow: 0 0 20px var(--red);
+  margin-bottom: 12px;
+}
+.alert-sub {
+  font-size: 14px;
+  color: #ff9999;
+  letter-spacing: 0.15em;
+  margin-bottom: 28px;
+  line-height: 1.8;
+}
+
+/* ---- Stage panels ---------------------------------------- */
+.stage-panel {
+  width: 100%;
+  max-width: 620px;
+  border: var(--border);
+  border-radius: 4px;
+  padding: 28px 32px;
+  background: rgba(0,255,65,0.02);
+  text-align: left;
+}
+.stage-label {
+  font-size: 10px;
+  letter-spacing: 0.3em;
+  color: var(--green-dim);
+  margin-bottom: 8px;
+  text-transform: uppercase;
+}
+.stage-title {
+  font-size: clamp(18px, 3vw, 26px);
+  font-weight: bold;
+  color: var(--green);
+  letter-spacing: 0.1em;
+  margin-bottom: 16px;
+  text-shadow: 0 0 10px var(--green-dim);
+}
+.stage-body {
+  font-size: 14px;
+  color: var(--white);
+  line-height: 1.8;
+  margin-bottom: 20px;
+}
+.stage-body code {
+  color: var(--amber);
+  background: rgba(255,170,0,0.08);
+  padding: 2px 6px;
+  border-radius: 2px;
+  font-size: 13px;
+}
+
+/* Terminal output block */
+.terminal-block {
+  background: #000;
+  border: 1px solid #1a3a1a;
+  border-radius: 3px;
+  padding: 14px 16px;
+  font-size: 13px;
+  color: var(--green-dim);
+  line-height: 1.7;
+  margin-bottom: 20px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.terminal-block .term-prompt { color: var(--green); }
+.terminal-block .term-value  { color: var(--amber); }
+.terminal-block .term-error  { color: var(--red); }
+
+/* ---- Fingerprint match display (stage 1) ----------------- */
+.fingerprint-display {
+  background: #000;
+  border: 1px solid #1a3a1a;
+  padding: 14px 16px;
+  border-radius: 3px;
+  margin-bottom: 20px;
+  font-size: 13px;
+  color: var(--green-dim);
+}
+.fingerprint-display .fp-label {
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  color: #446644;
+  margin-bottom: 6px;
+}
+.fingerprint-display .fp-value {
+  color: var(--amber);
+  font-size: 16px;
+  letter-spacing: 0.15em;
+}
+
+/* ---- Key status slots ------------------------------------ */
+.key-slots {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+.key-slot {
+  flex: 1;
+  min-width: 180px;
+  border: 2px solid var(--gray);
+  border-radius: 4px;
+  padding: 16px;
+  text-align: center;
+  transition: border-color 0.3s, background 0.3s;
+}
+.key-slot.waiting {
+  border-color: var(--gray);
+  animation: slotPulse 2s ease-in-out infinite;
+}
+.key-slot.authenticated {
+  border-color: var(--green);
+  background: rgba(0,255,65,0.05);
+}
+.key-slot.error {
+  border-color: var(--red);
+  background: rgba(255,34,34,0.05);
+}
+@keyframes slotPulse {
+  0%, 100% { border-color: var(--gray); box-shadow: none; }
+  50%       { border-color: var(--green-dim); box-shadow: 0 0 10px rgba(0,255,65,0.2); }
+}
+.key-slot-icon { font-size: 28px; margin-bottom: 8px; }
+.key-slot-label {
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  color: var(--green-dim);
+  margin-bottom: 4px;
+}
+.key-slot-status {
+  font-size: 13px;
+  font-weight: bold;
+  color: var(--gray);
+}
+.key-slot.authenticated .key-slot-status { color: var(--green); }
+.key-slot.waiting       .key-slot-status { color: var(--amber); }
+.key-slot.error         .key-slot-status { color: var(--red); }
+
+/* ---- Codeword input (stage 3) ---------------------------- */
+.code-input-row {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+.code-char-box {
+  width: 52px;
+  height: 64px;
+  border: 2px solid var(--green-dim);
+  border-radius: 4px;
+  background: rgba(0,255,65,0.04);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  font-weight: bold;
+  color: var(--green);
+  letter-spacing: 0;
+  transition: border-color 0.2s, background 0.2s;
+}
+.code-char-box.filled {
+  border-color: var(--green);
+  background: rgba(0,255,65,0.10);
+}
+.code-char-box.error {
+  border-color: var(--red);
+  background: rgba(255,34,34,0.08);
+  animation: charShake 0.3s ease;
+}
+@keyframes charShake {
+  0%,100% { transform: translateX(0); }
+  33%     { transform: translateX(-5px); }
+  66%     { transform: translateX(5px); }
+}
+
+/* ---- Stage 2: Cipher display ----------------------------- */
+.cipher-display {
+  background: #000;
+  border: 1px solid #1a3a1a;
+  padding: 20px;
+  border-radius: 3px;
+  margin-bottom: 20px;
+  text-align: center;
+}
+.cipher-label {
+  font-size: 10px;
+  letter-spacing: 0.25em;
+  color: #446644;
+  margin-bottom: 10px;
+}
+.cipher-encoded {
+  font-size: clamp(18px, 3vw, 26px);
+  letter-spacing: 0.2em;
+  color: var(--amber);
+  text-shadow: 0 0 8px rgba(255,170,0,0.5);
+}
+.cipher-hint {
+  font-size: 11px;
+  color: #446644;
+  margin-top: 10px;
+  letter-spacing: 0.15em;
+}
+
+/* ---- Win screen ------------------------------------------ */
+#screen-win {
+  background: #001408;
+}
+.win-box {
+  border: 2px solid var(--green);
+  border-radius: 4px;
+  padding: 40px 48px;
+  max-width: 560px;
+  width: 100%;
+  box-shadow: 0 0 60px rgba(0,255,65,0.2), inset 0 0 40px rgba(0,255,65,0.04);
+  animation: winGlow 2s ease-in-out infinite;
+}
+@keyframes winGlow {
+  0%, 100% { box-shadow: 0 0 40px rgba(0,255,65,0.2), inset 0 0 40px rgba(0,255,65,0.04); }
+  50%       { box-shadow: 0 0 80px rgba(0,255,65,0.4), inset 0 0 60px rgba(0,255,65,0.08); }
+}
+.win-title {
+  font-size: clamp(20px, 4vw, 32px);
+  font-weight: bold;
+  letter-spacing: 0.2em;
+  color: var(--green);
+  text-shadow: 0 0 20px var(--green);
+  margin-bottom: 8px;
+}
+.win-sub {
+  font-size: 13px;
+  letter-spacing: 0.2em;
+  color: var(--green-dim);
+  margin-bottom: 24px;
+}
+.win-time {
+  font-size: 18px;
+  color: var(--amber);
+  margin-bottom: 20px;
+}
+.win-message {
+  font-size: 14px;
+  color: var(--white);
+  margin-bottom: 28px;
+  line-height: 1.7;
+}
+.win-qr {
+  margin: 0 auto 20px;
+  width: 120px;
+  height: 120px;
+  background: white;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  color: #333;
+  text-align: center;
+  padding: 4px;
+}
+
+/* ---- Fail screen ----------------------------------------- */
+#screen-fail {
+  background: var(--red-dark);
+}
+.fail-title {
+  font-size: clamp(24px, 5vw, 40px);
+  font-weight: bold;
+  letter-spacing: 0.2em;
+  color: var(--red);
+  text-shadow: 0 0 20px var(--red);
+  margin-bottom: 12px;
+}
+.fail-sub {
+  font-size: 14px;
+  color: #ff9999;
+  letter-spacing: 0.1em;
+  margin-bottom: 28px;
+  line-height: 1.8;
+}
+
+/* ---- Confetti -------------------------------------------- */
+.confetti-piece {
+  position: fixed;
+  width: 10px;
+  height: 10px;
+  top: -10px;
+  border-radius: 2px;
+  animation: confettiFall linear forwards;
+  pointer-events: none;
+  z-index: 9998;
+}
+@keyframes confettiFall {
+  0%   { transform: translateY(0) rotate(0deg); opacity: 1; }
+  100% { transform: translateY(110vh) rotate(720deg); opacity: 0; }
+}
+
+/* ---- Status messages ------------------------------------- */
+.status-msg {
+  font-size: 13px;
+  letter-spacing: 0.1em;
+  min-height: 20px;
+  margin-bottom: 12px;
+}
+.status-msg.ok    { color: var(--green); }
+.status-msg.error { color: var(--red); }
+.status-msg.info  { color: var(--amber); }
+
+/* ---- Hidden YubiKey input -------------------------------- */
+#yubikey-input {
+  position: fixed;
+  left: -9999px;
+  top: 0;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+
+/* ---- Utility --------------------------------------------- */
+.mt-12 { margin-top: 12px; }
+.mt-20 { margin-top: 20px; }
+.text-center { text-align: center; }
+.text-dim { color: var(--green-dim); }
+.text-amber { color: var(--amber); }
+.text-red { color: var(--red); }
+.blink {
+  animation: blink 1s step-end infinite;
+}
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
+}
+
+/* ---- Session code display (volunteer reference) ---------- */
+#session-code-display {
+  position: fixed;
+  bottom: 14px;
+  left: 16px;
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  color: var(--green-dim);
+  opacity: 0.45;
+  z-index: 200;
+  pointer-events: none;
+}
+#session-code-display #session-code-value {
+  color: var(--amber);
+}
+
+/* ---- Yubico sponsor badge -------------------------------- */
+#yubico-badge {
+  position: fixed;
+  bottom: 14px;
+  right: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  background: rgba(255,255,255,0.93);
+  border-radius: 5px;
+  padding: 6px 10px 5px;
+  text-decoration: none;
+  opacity: 0.65;
+  transition: opacity 0.2s, box-shadow 0.2s;
+  z-index: 200;
+  pointer-events: auto;
+}
+.yubico-powered-label {
+  font-family: var(--font-mono);
+  font-size: 7px;
+  letter-spacing: 0.25em;
+  color: #777;
+  line-height: 1;
+}
+.yubico-logo-img {
+  display: block;
+  height: 16px;
+  width: auto;
+}
+
+/* ---- Responsive for iPad --------------------------------- */
+@media (max-width: 768px) {
+  .screen { padding: 20px 16px; }
+  #hud.visible ~ .screen.active { padding-top: 48px; }
+  .stage-panel { padding: 20px 18px; }
+  .win-box { padding: 28px 24px; }
+  .login-panel { width: 100%; max-width: 340px; }
+  .key-slot { min-width: 140px; }
+}

--- a/assets/css/escape-room.css
+++ b/assets/css/escape-room.css
@@ -596,14 +596,57 @@ body::after {
 .status-msg.error { color: var(--red); }
 .status-msg.info  { color: var(--amber); }
 
-/* ---- Hidden YubiKey input -------------------------------- */
-#yubikey-input {
-  position: fixed;
-  left: -9999px;
-  top: 0;
-  width: 1px;
-  height: 1px;
-  opacity: 0;
+/* ---- YubiKey reader input (stages 1 & 4) ----------------- */
+.yk-reader-wrap {
+  margin-top: 16px;
+  text-align: center;
+}
+.yk-reader-label {
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  color: var(--green-dim);
+  margin-bottom: 8px;
+  transition: color 0.2s;
+}
+.yk-reader-wrap.active .yk-reader-label {
+  color: var(--amber);
+  animation: readerPulse 1.4s ease-in-out infinite;
+}
+@keyframes readerPulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.45; }
+}
+.yk-reader-input {
+  display: block;
+  width: 100%;
+  padding: 16px 20px;
+  background: #050f05;
+  border: 2px solid var(--green-dim);
+  border-radius: 4px;
+  color: var(--green-dim);
+  caret-color: var(--green);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-align: center;
+  outline: none;
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s, background 0.15s, color 0.15s;
+  -webkit-user-select: text;
+  user-select: text;
+}
+.yk-reader-input::placeholder {
+  color: var(--green-dim);
+  letter-spacing: 0.18em;
+}
+.yk-reader-wrap.active .yk-reader-input {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 3px rgba(255,170,0,0.15), 0 0 20px rgba(255,170,0,0.08);
+  background: rgba(255,170,0,0.03);
+  color: var(--amber);
+}
+.yk-reader-wrap.active .yk-reader-input::placeholder {
+  color: var(--amber);
 }
 
 /* ---- Utility --------------------------------------------- */

--- a/assets/css/escape-room.css
+++ b/assets/css/escape-room.css
@@ -241,6 +241,15 @@ body::after {
 .login-field input:focus {
   border-color: #7788ff;
 }
+.login-field input[readonly] {
+  color: #778;
+  background: #0c0c18;
+  border-color: #2a2a44;
+  cursor: default;
+}
+.login-field input[readonly]:focus {
+  border-color: #2a2a44;
+}
 .login-submit {
   width: 100%;
   padding: 11px;

--- a/assets/js/escape-room.js
+++ b/assets/js/escape-room.js
@@ -1,0 +1,528 @@
+// ============================================================
+// CERBERUS ESCAPE ROOM — APP.JS
+// State machine + puzzle logic. No dependencies.
+// ============================================================
+
+// ---- State -------------------------------------------------
+const State = {
+  INTRO:     'INTRO',
+  STAGE_0:   'STAGE_0',   // Lockdown screen (after bad login triggers alert)
+  STAGE_1:   'STAGE_1',   // Identify key & plug in Key A
+  STAGE_2:   'STAGE_2',   // Decode cipher
+  STAGE_3:   'STAGE_3',   // Enter codeword
+  STAGE_4:   'STAGE_4',   // Dual auth with Key B
+  WIN:       'WIN',
+  FAIL:      'FAIL',
+};
+
+let currentState = State.INTRO;
+let timerInterval = null;
+let secondsLeft = CONFIG.TIMER_SECONDS;
+let keyAAuthenticated = false;
+let keyBAuthenticated = false;
+let otpBuffer = "";
+let activeCredential = null;
+let sessionCode = '—';
+
+// ---- Credential picker -------------------------------------
+function pickCredential() {
+  const creds = CONFIG.LOGIN_CREDENTIALS;
+  const idx = Math.floor(Math.random() * creds.length);
+  activeCredential = creds[idx];
+  sessionCode = String.fromCharCode(65 + idx); // 0→A, 1→B, 2→C, 3→D
+
+  const codeEl = document.getElementById('session-code-value');
+  if (codeEl) codeEl.textContent = sessionCode;
+}
+
+// ---- Init --------------------------------------------------
+document.addEventListener('DOMContentLoaded', () => {
+  pickCredential();
+  setupLoginForm();
+  setupYubiKeyListener();
+  showScreen('screen-intro');
+});
+
+// ---- Screen routing ----------------------------------------
+function showScreen(screenId) {
+  document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
+  const target = document.getElementById(screenId);
+  if (target) target.classList.add('active');
+}
+
+function setHUD(visible, stageText) {
+  const hud = document.getElementById('hud');
+  if (visible) {
+    hud.classList.add('visible');
+    document.getElementById('hud-stage').textContent = stageText || '';
+  } else {
+    hud.classList.remove('visible');
+  }
+}
+
+// ---- Timer -------------------------------------------------
+function startTimer() {
+  secondsLeft = CONFIG.TIMER_SECONDS;
+  renderTimer();
+  timerInterval = setInterval(() => {
+    secondsLeft--;
+    renderTimer();
+    if (secondsLeft <= 0) {
+      clearInterval(timerInterval);
+      goFail();
+    }
+  }, 1000);
+}
+
+function stopTimer() {
+  if (timerInterval) {
+    clearInterval(timerInterval);
+    timerInterval = null;
+  }
+}
+
+function renderTimer() {
+  const el = document.getElementById('hud-timer');
+  const m = Math.floor(secondsLeft / 60).toString().padStart(2, '0');
+  const s = (secondsLeft % 60).toString().padStart(2, '0');
+  el.textContent = `T-${m}:${s}`;
+  el.classList.remove('warning', 'danger');
+  if (secondsLeft <= 30)       el.classList.add('danger');
+  else if (secondsLeft <= 90)  el.classList.add('warning');
+}
+
+function getTimeRemaining() {
+  const m = Math.floor(secondsLeft / 60).toString().padStart(2, '0');
+  const s = (secondsLeft % 60).toString().padStart(2, '0');
+  return `${m}:${s}`;
+}
+
+// ---- Intro -------------------------------------------------
+function beginMission() {
+  playSound('beep');
+  currentState = State.STAGE_0;
+  showScreen('screen-stage0');
+  // HUD not shown yet — timer starts after lockdown trigger
+}
+
+// ---- Stage 0: Login form -----------------------------------
+function setupLoginForm() {
+  const form = document.getElementById('login-form');
+  if (!form) return;
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    handleLogin();
+  });
+}
+
+function handleLogin() {
+  const emailEl = document.getElementById('login-email');
+  const passEl  = document.getElementById('login-pass');
+  const errEl   = document.getElementById('login-error');
+
+  const email = emailEl.value.trim();
+  const pass  = passEl.value;
+
+  // Wrong credentials — show error and stay on login
+  if (email !== activeCredential.email || pass !== activeCredential.password) {
+    errEl.textContent = "Authentication failed. Check your credentials.";
+    passEl.value = '';
+    passEl.focus();
+    playSound('beep');
+    return;
+  }
+
+  // Correct credentials → trigger the drama
+  errEl.textContent = '';
+  playSound('alarm');
+
+  // Brief "Welcome back" flash before lockdown
+  const panel = document.querySelector('.login-panel');
+  panel.style.transition = 'opacity 0.3s';
+  panel.style.opacity = '0';
+
+  setTimeout(() => {
+    transitionToLockdown();
+  }, 600);
+}
+
+function transitionToLockdown() {
+  currentState = State.STAGE_1; // Move past stage 0 — lockdown is the bridge
+  showScreen('screen-lockdown');
+  setHUD(true, '● LOCKDOWN ACTIVE');
+  startTimer();
+  focusYubiKeyInput();
+}
+
+// ---- Stage 1: Identify the breach + plug in Key A ----------
+function enterStage1() {
+  currentState = State.STAGE_1;
+  showScreen('screen-stage1');
+  setHUD(true, '● STAGE 1 — IDENTIFY BREACH');
+
+  // Show the target fingerprint suffix
+  const el = document.getElementById('stage1-fp');
+  if (el) {
+    const target = CONFIG.ROSTER.find(r => r.isTarget);
+    el.textContent = `...${target ? target.keySuffix : '????'}`;
+  }
+  const demoBtn = document.getElementById('demo-key-a');
+  if (demoBtn) demoBtn.style.display = CONFIG.YUBIKEY_REQUIRED ? 'none' : 'block';
+  setStage1Status('info', CONFIG.YUBIKEY_REQUIRED ? 'Plug in the correct YubiKey and touch it.' : 'Demo mode: use the button below to simulate a key touch.');
+  focusYubiKeyInput();
+}
+
+function setStage1Status(type, msg) {
+  const el = document.getElementById('stage1-status');
+  if (!el) return;
+  el.className = `status-msg ${type}`;
+  el.textContent = msg;
+}
+
+// ---- Stage 2: Cipher display -------------------------------
+function enterStage2() {
+  currentState = State.STAGE_2;
+  showScreen('screen-stage2');
+  setHUD(true, '● STAGE 2 — DECRYPT MESSAGE');
+
+  const el = document.getElementById('stage2-encoded');
+  if (el) el.textContent = CONFIG.ENCODED_MESSAGE;
+  focusYubiKeyInput();
+}
+
+// Stage 2 advances automatically via button — no YubiKey needed
+function stage2Continue() {
+  playSound('beep');
+  enterStage3();
+}
+
+// ---- Stage 3: Enter codeword -------------------------------
+let codewordBuffer = '';
+
+function enterStage3() {
+  currentState = State.STAGE_3;
+  codewordBuffer = '';
+  showScreen('screen-stage3');
+  setHUD(true, '● STAGE 3 — ENTER CODEWORD');
+
+  const refEl = document.getElementById('stage3-encoded-ref');
+  if (refEl) refEl.textContent = CONFIG.ENCODED_MESSAGE;
+
+  renderCodeword();
+  setStage3Status('info', 'Type the decoded codeword on the keyboard.');
+  // For stage 3, we capture keypresses directly (not YubiKey)
+  focusYubiKeyInput();
+}
+
+function renderCodeword() {
+  const boxes = document.querySelectorAll('.code-char-box');
+  boxes.forEach((box, i) => {
+    const ch = codewordBuffer[i] || '';
+    box.textContent = ch;
+    box.classList.toggle('filled', ch !== '');
+    box.classList.remove('error');
+  });
+}
+
+function setStage3Status(type, msg) {
+  const el = document.getElementById('stage3-status');
+  if (!el) return;
+  el.className = `status-msg ${type}`;
+  el.textContent = msg;
+}
+
+// ---- Stage 4: Dual auth ------------------------------------
+function enterStage4() {
+  currentState = State.STAGE_4;
+  showScreen('screen-stage4');
+  setHUD(true, '● STAGE 4 — DUAL AUTHENTICATION');
+
+  // Key A slot is already filled
+  setSlotState('slot-a', 'authenticated', '✓ AUTHENTICATED');
+  setSlotState('slot-b', 'waiting', 'INSERT KEY B');
+
+  const hint = document.getElementById('stage4-hint');
+  if (hint) hint.textContent = CONFIG.KEY_B_HINT;
+
+  const demoBtn = document.getElementById('demo-key-b');
+  if (demoBtn) demoBtn.style.display = CONFIG.YUBIKEY_REQUIRED ? 'none' : 'block';
+  setStage4Status('info', CONFIG.YUBIKEY_REQUIRED ? 'Locate Key B and plug it in, then touch it.' : 'Demo mode: use the button below to simulate a key touch.');
+  focusYubiKeyInput();
+}
+
+function setSlotState(slotId, className, statusText) {
+  const slot = document.getElementById(slotId);
+  if (!slot) return;
+  slot.className = `key-slot ${className}`;
+  const statusEl = slot.querySelector('.key-slot-status');
+  if (statusEl) statusEl.textContent = statusText;
+}
+
+function setStage4Status(type, msg) {
+  const el = document.getElementById('stage4-status');
+  if (!el) return;
+  el.className = `status-msg ${type}`;
+  el.textContent = msg;
+}
+
+// ---- Win / Fail --------------------------------------------
+function goWin() {
+  stopTimer();
+  currentState = State.WIN;
+  showScreen('screen-win');
+  setHUD(false);
+  playSound('success');
+
+  const timeEl = document.getElementById('win-time');
+  if (timeEl) timeEl.textContent = `Time remaining: ${getTimeRemaining()}`;
+
+  setTimeout(() => spawnConfetti(), 300);
+}
+
+function goFail() {
+  stopTimer();
+  currentState = State.FAIL;
+  showScreen('screen-fail');
+  setHUD(false);
+  playSound('alarm');
+}
+
+function resetGame() {
+  stopTimer();
+  currentState = State.INTRO;
+  keyAAuthenticated = false;
+  keyBAuthenticated = false;
+  otpBuffer = '';
+  codewordBuffer = '';
+  secondsLeft = CONFIG.TIMER_SECONDS;
+  pickCredential();
+
+  // Reset login form
+  const emailEl = document.getElementById('login-email');
+  const passEl  = document.getElementById('login-pass');
+  const errEl   = document.getElementById('login-error');
+  if (emailEl) emailEl.value = '';
+  if (passEl)  passEl.value  = '';
+  if (errEl)   errEl.textContent = '';
+
+  const panel = document.querySelector('.login-panel');
+  if (panel) { panel.style.opacity = ''; panel.style.transition = ''; }
+
+  setHUD(false);
+  showScreen('screen-intro');
+}
+
+// ---- YubiKey listener -------------------------------------
+// The YubiKey types its OTP as fast keystrokes, ending with Enter.
+// We keep a hidden input focused during stages that need it,
+// and listen for keydown to detect End-of-OTP.
+
+function setupYubiKeyListener() {
+  const input = document.getElementById('yubikey-input');
+  if (!input) return;
+
+  // Capture typing into otpBuffer (for YubiKey OTP stages)
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      const otp = input.value.trim();
+      input.value = '';
+      if (otp.length > 0) {
+        handleOTPOrKeypress(otp);
+      }
+    }
+  });
+
+  // Also intercept body keydown for stage 3 (regular keyboard)
+  document.addEventListener('keydown', (e) => {
+    handleBodyKeydown(e);
+  });
+}
+
+function focusYubiKeyInput() {
+  const input = document.getElementById('yubikey-input');
+  if (input) {
+    // Small delay ensures the screen transition has settled
+    setTimeout(() => input.focus(), 100);
+  }
+}
+
+// Refocus hidden input if user taps anywhere during key stages
+document.addEventListener('click', () => {
+  if ([State.STAGE_1, State.STAGE_4].includes(currentState)) {
+    focusYubiKeyInput();
+  }
+});
+
+// ---- Keyboard handler for stage 3 codeword entry ----------
+function handleBodyKeydown(e) {
+  if (currentState !== State.STAGE_3) return;
+  if (e.target.id === 'login-email' || e.target.id === 'login-pass') return;
+
+  const key = e.key.toUpperCase();
+
+  if (e.key === 'Backspace') {
+    codewordBuffer = codewordBuffer.slice(0, -1);
+    renderCodeword();
+    setStage3Status('info', 'Type the decoded codeword on the keyboard.');
+    return;
+  }
+
+  if (e.key === 'Enter') {
+    validateCodeword();
+    return;
+  }
+
+  if (/^[A-Z]$/.test(key) && codewordBuffer.length < CONFIG.CODEWORD.length) {
+    codewordBuffer += key;
+    renderCodeword();
+
+    if (codewordBuffer.length === CONFIG.CODEWORD.length) {
+      setTimeout(validateCodeword, 200);
+    }
+  }
+}
+
+function validateCodeword() {
+  if (codewordBuffer.toUpperCase() === CONFIG.CODEWORD.toUpperCase()) {
+    setStage3Status('ok', '✓ Codeword accepted. Sequence partially halted.');
+    playSound('beep');
+    // Mark boxes green briefly, then advance
+    document.querySelectorAll('.code-char-box').forEach(b => b.classList.add('filled'));
+    setTimeout(() => enterStage4(), 1200);
+  } else {
+    setStage3Status('error', '✗ Invalid codeword. Try again.');
+    playSound('beep');
+    document.querySelectorAll('.code-char-box').forEach(b => b.classList.add('error'));
+    setTimeout(() => {
+      codewordBuffer = '';
+      renderCodeword();
+      setStage3Status('info', 'Type the decoded codeword on the keyboard.');
+    }, 900);
+  }
+}
+
+// ---- OTP handler (YubiKey stages 1 & 4) -------------------
+function handleOTPOrKeypress(otp) {
+  switch (currentState) {
+    case State.STAGE_1:
+      handleStage1OTP(otp);
+      break;
+    case State.STAGE_4:
+      handleStage4OTP(otp);
+      break;
+    default:
+      break;
+  }
+}
+
+function identifyKey(otp) {
+  const prefix = otp.slice(0, 12);
+  if (prefix === CONFIG.KEY_A_PREFIX) return 'A';
+  if (prefix === CONFIG.KEY_B_PREFIX) return 'B';
+  return null;
+}
+
+function handleStage1OTP(otp) {
+  const key = identifyKey(otp);
+
+  if (key === 'A') {
+    keyAAuthenticated = true;
+    setStage1Status('ok', '✓ Token verified. Commit author confirmed: A. Wright');
+    playSound('beep');
+    setTimeout(() => enterStage2(), 1400);
+  } else if (key === 'B') {
+    setStage1Status('error', '✗ Wrong key. Check the roster and select the correct one.');
+    playSound('beep');
+  } else if (otp.length >= 32) {
+    // Looks like a YubiKey OTP but prefix doesn't match either known key
+    setStage1Status('error', '✗ Unrecognized key. Not in CERBERUS registry.');
+    playSound('beep');
+  } else {
+    // Probably noise / accidental input — ignore silently
+  }
+  focusYubiKeyInput();
+}
+
+function handleStage4OTP(otp) {
+  const key = identifyKey(otp);
+
+  if (key === 'B' && !keyBAuthenticated) {
+    keyBAuthenticated = true;
+    setSlotState('slot-b', 'authenticated', '✓ AUTHENTICATED');
+    setStage4Status('ok', '✓ Dual authentication complete. Aborting sequence...');
+    playSound('beep');
+    setTimeout(() => goWin(), 1600);
+  } else if (key === 'A') {
+    setStage4Status('error', '✗ Key A already used. A different key is required.');
+    playSound('beep');
+    focusYubiKeyInput();
+  } else if (key === 'B' && keyBAuthenticated) {
+    // Already done — shouldn't happen but handle gracefully
+    goWin();
+  } else if (otp.length >= 32) {
+    setStage4Status('error', '✗ Unrecognized key. Locate the correct secondary key.');
+    playSound('beep');
+    focusYubiKeyInput();
+  }
+}
+
+// ---- Confetti ----------------------------------------------
+function spawnConfetti() {
+  const colors = ['#00ff41', '#ffaa00', '#00aaff', '#ff44aa', '#ffffff'];
+  for (let i = 0; i < 80; i++) {
+    const piece = document.createElement('div');
+    piece.className = 'confetti-piece';
+    piece.style.left = Math.random() * 100 + 'vw';
+    piece.style.background = colors[Math.floor(Math.random() * colors.length)];
+    piece.style.width  = (Math.random() * 8 + 6) + 'px';
+    piece.style.height = (Math.random() * 8 + 6) + 'px';
+    piece.style.animationDuration = (Math.random() * 2 + 2.5) + 's';
+    piece.style.animationDelay    = (Math.random() * 1.5) + 's';
+    document.body.appendChild(piece);
+    piece.addEventListener('animationend', () => piece.remove());
+  }
+}
+
+// ---- Audio -------------------------------------------------
+const audioCache = {};
+
+function playSound(name) {
+  if (!CONFIG.AUDIO_ENABLED) return;
+  try {
+    const map = { beep: 'sounds/beep.mp3', success: 'sounds/success.mp3', alarm: 'sounds/alarm.mp3' };
+    const src = map[name];
+    if (!src) return;
+    if (!audioCache[name]) {
+      audioCache[name] = new Audio(src);
+    }
+    const audio = audioCache[name].cloneNode();
+    audio.volume = 0.7;
+    audio.play().catch(() => {}); // ignore autoplay policy errors
+  } catch (e) { /* silent fail */ }
+}
+
+// ---- Demo mode simulation ----------------------------------
+// Called by the on-screen buttons when YUBIKEY_REQUIRED is false.
+// Constructs a mock OTP with the correct prefix so the normal
+// key-identification logic passes without a physical key.
+function simulateKeyA() {
+  handleOTPOrKeypress(CONFIG.KEY_A_PREFIX + 'x'.repeat(32));
+}
+
+function simulateKeyB() {
+  handleOTPOrKeypress(CONFIG.KEY_B_PREFIX + 'x'.repeat(32));
+}
+
+// ---- Lockdown continue button ------------------------------
+function lockdownContinue() {
+  playSound('beep');
+  enterStage1();
+}
+
+// ---- Expose to HTML ----------------------------------------
+window.beginMission     = beginMission;
+window.lockdownContinue = lockdownContinue;
+window.stage2Continue   = stage2Continue;
+window.resetGame        = resetGame;
+window.simulateKeyA     = simulateKeyA;
+window.simulateKeyB     = simulateKeyB;

--- a/assets/js/escape-room.js
+++ b/assets/js/escape-room.js
@@ -23,13 +23,17 @@ let keyBAuthenticated = false;
 let otpBuffer = "";
 let activeCredential = null;
 let sessionCode = '—';
+let targetUserA = null; // randomly chosen Stage 1 target (changes each game)
 
-// ---- Credential picker -------------------------------------
+// ---- Credential / target picker ----------------------------
+// Picks one eligible roster member to use for both Stage 0 (login)
+// and Stage 1 (Key A). Eligible = has a keyPrefix and is not KEY_B_USER_ID.
 function pickCredential() {
-  const creds = CONFIG.LOGIN_CREDENTIALS;
-  const idx = Math.floor(Math.random() * creds.length);
-  activeCredential = creds[idx];
-  sessionCode = String.fromCharCode(65 + idx); // 0→A, 1→B, 2→C, 3→D
+  const eligible = CONFIG.ROSTER.filter(r => r.id !== CONFIG.KEY_B_USER_ID && r.keyPrefix);
+  const idx = eligible.length ? Math.floor(Math.random() * eligible.length) : 0;
+  activeCredential = eligible[idx] || null;
+  targetUserA      = activeCredential;
+  sessionCode = String.fromCharCode(65 + idx); // 0→A, 1→B, 2→C, …
 
   const codeEl = document.getElementById('session-code-value');
   if (codeEl) codeEl.textContent = sessionCode;
@@ -97,10 +101,24 @@ function getTimeRemaining() {
   return `${m}:${s}`;
 }
 
+// ---- Stage enable helpers ----------------------------------
+function isStageEnabled(n) {
+  try {
+    const stored = localStorage.getItem('campfire_stages');
+    if (stored) {
+      const cfg = JSON.parse(stored);
+      return cfg[`s${n}`] !== false;
+    }
+  } catch (e) {}
+  // Fall back to config.js defaults
+  return CONFIG.STAGES_ENABLED ? CONFIG.STAGES_ENABLED[`s${n}`] !== false : true;
+}
+
 // ---- Intro -------------------------------------------------
 function beginMission() {
   playSound('beep');
   currentState = State.STAGE_0;
+  if (!isStageEnabled(0)) { transitionToLockdown(); return; }
   showScreen('screen-stage0');
   // HUD not shown yet — timer starts after lockdown trigger
 }
@@ -151,7 +169,6 @@ function transitionToLockdown() {
   showScreen('screen-lockdown');
   setHUD(true, '● LOCKDOWN ACTIVE');
   startTimer();
-  focusYubiKeyInput();
 }
 
 // ---- Stage 1: Identify the breach + plug in Key A ----------
@@ -163,13 +180,11 @@ function enterStage1() {
   // Show the target fingerprint suffix
   const el = document.getElementById('stage1-fp');
   if (el) {
-    const target = CONFIG.ROSTER.find(r => r.isTarget);
-    el.textContent = `...${target ? target.keySuffix : '????'}`;
+    el.textContent = `...${targetUserA ? targetUserA.keySuffix : '????'}`;
   }
   const demoBtn = document.getElementById('demo-key-a');
   if (demoBtn) demoBtn.style.display = CONFIG.YUBIKEY_REQUIRED ? 'none' : 'block';
   setStage1Status('info', CONFIG.YUBIKEY_REQUIRED ? 'Plug in the correct YubiKey and touch it.' : 'Demo mode: use the button below to simulate a key touch.');
-  focusYubiKeyInput();
 }
 
 function setStage1Status(type, msg) {
@@ -181,13 +196,13 @@ function setStage1Status(type, msg) {
 
 // ---- Stage 2: Cipher display -------------------------------
 function enterStage2() {
+  if (!isStageEnabled(2)) { enterStage3(); return; }
   currentState = State.STAGE_2;
   showScreen('screen-stage2');
   setHUD(true, '● STAGE 2 — DECRYPT MESSAGE');
 
   const el = document.getElementById('stage2-encoded');
   if (el) el.textContent = CONFIG.ENCODED_MESSAGE;
-  focusYubiKeyInput();
 }
 
 // Stage 2 advances automatically via button — no YubiKey needed
@@ -200,6 +215,7 @@ function stage2Continue() {
 let codewordBuffer = '';
 
 function enterStage3() {
+  if (!isStageEnabled(3)) { enterStage4(); return; }
   currentState = State.STAGE_3;
   codewordBuffer = '';
   showScreen('screen-stage3');
@@ -210,8 +226,7 @@ function enterStage3() {
 
   renderCodeword();
   setStage3Status('info', 'Type the decoded codeword on the keyboard.');
-  // For stage 3, we capture keypresses directly (not YubiKey)
-  focusYubiKeyInput();
+  // For stage 3, we capture keypresses directly via document keydown (not YubiKey input)
 }
 
 function renderCodeword() {
@@ -233,6 +248,7 @@ function setStage3Status(type, msg) {
 
 // ---- Stage 4: Dual auth ------------------------------------
 function enterStage4() {
+  if (!isStageEnabled(4)) { goWin(); return; }
   currentState = State.STAGE_4;
   showScreen('screen-stage4');
   setHUD(true, '● STAGE 4 — DUAL AUTHENTICATION');
@@ -247,7 +263,6 @@ function enterStage4() {
   const demoBtn = document.getElementById('demo-key-b');
   if (demoBtn) demoBtn.style.display = CONFIG.YUBIKEY_REQUIRED ? 'none' : 'block';
   setStage4Status('info', CONFIG.YUBIKEY_REQUIRED ? 'Locate Key B and plug it in, then touch it.' : 'Demo mode: use the button below to simulate a key touch.');
-  focusYubiKeyInput();
 }
 
 function setSlotState(slotId, className, statusText) {
@@ -314,44 +329,36 @@ function resetGame() {
 
 // ---- YubiKey listener -------------------------------------
 // The YubiKey types its OTP as fast keystrokes, ending with Enter.
-// We keep a hidden input focused during stages that need it,
-// and listen for keydown to detect End-of-OTP.
+// Each YubiKey stage has its own visible input the player taps to activate.
+// inputmode="none" prevents the software keyboard from appearing on iPad
+// while still accepting input from the YubiKey (a hardware HID device).
 
 function setupYubiKeyListener() {
-  const input = document.getElementById('yubikey-input');
-  if (!input) return;
+  ['yubikey-input-s1', 'yubikey-input-s4'].forEach(id => {
+    const input = document.getElementById(id);
+    if (!input) return;
 
-  // Capture typing into otpBuffer (for YubiKey OTP stages)
-  input.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') {
-      const otp = input.value.trim();
-      input.value = '';
-      if (otp.length > 0) {
-        handleOTPOrKeypress(otp);
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        const otp = input.value.trim();
+        input.value = '';
+        if (otp.length > 0) handleOTPOrKeypress(otp);
       }
-    }
+    });
+
+    input.addEventListener('focus', () => {
+      input.closest('.yk-reader-wrap').classList.add('active');
+    });
+    input.addEventListener('blur', () => {
+      input.closest('.yk-reader-wrap').classList.remove('active');
+    });
   });
 
-  // Also intercept body keydown for stage 3 (regular keyboard)
+  // Stage 3 codeword entry uses regular keyboard via body keydown
   document.addEventListener('keydown', (e) => {
     handleBodyKeydown(e);
   });
 }
-
-function focusYubiKeyInput() {
-  const input = document.getElementById('yubikey-input');
-  if (input) {
-    // Small delay ensures the screen transition has settled
-    setTimeout(() => input.focus(), 100);
-  }
-}
-
-// Refocus hidden input if user taps anywhere during key stages
-document.addEventListener('click', () => {
-  if ([State.STAGE_1, State.STAGE_4].includes(currentState)) {
-    focusYubiKeyInput();
-  }
-});
 
 // ---- Keyboard handler for stage 3 codeword entry ----------
 function handleBodyKeydown(e) {
@@ -417,8 +424,9 @@ function handleOTPOrKeypress(otp) {
 
 function identifyKey(otp) {
   const prefix = otp.slice(0, 12);
-  if (prefix === CONFIG.KEY_A_PREFIX) return 'A';
-  if (prefix === CONFIG.KEY_B_PREFIX) return 'B';
+  const keyBUser = CONFIG.ROSTER.find(r => r.id === CONFIG.KEY_B_USER_ID);
+  if (targetUserA && prefix === targetUserA.keyPrefix) return 'A';
+  if (keyBUser && prefix === keyBUser.keyPrefix) return 'B';
   return null;
 }
 
@@ -427,7 +435,8 @@ function handleStage1OTP(otp) {
 
   if (key === 'A') {
     keyAAuthenticated = true;
-    setStage1Status('ok', '✓ Token verified. Commit author confirmed: A. Wright');
+    const name = targetUserA ? targetUserA.name : 'unknown';
+    setStage1Status('ok', `✓ Token verified. Commit author confirmed: ${name}`);
     playSound('beep');
     setTimeout(() => enterStage2(), 1400);
   } else if (key === 'B') {
@@ -440,7 +449,6 @@ function handleStage1OTP(otp) {
   } else {
     // Probably noise / accidental input — ignore silently
   }
-  focusYubiKeyInput();
 }
 
 function handleStage4OTP(otp) {
@@ -455,14 +463,12 @@ function handleStage4OTP(otp) {
   } else if (key === 'A') {
     setStage4Status('error', '✗ Key A already used. A different key is required.');
     playSound('beep');
-    focusYubiKeyInput();
   } else if (key === 'B' && keyBAuthenticated) {
     // Already done — shouldn't happen but handle gracefully
     goWin();
   } else if (otp.length >= 32) {
     setStage4Status('error', '✗ Unrecognized key. Locate the correct secondary key.');
     playSound('beep');
-    focusYubiKeyInput();
   }
 }
 
@@ -506,16 +512,20 @@ function playSound(name) {
 // Constructs a mock OTP with the correct prefix so the normal
 // key-identification logic passes without a physical key.
 function simulateKeyA() {
-  handleOTPOrKeypress(CONFIG.KEY_A_PREFIX + 'x'.repeat(32));
+  const prefix = targetUserA ? targetUserA.keyPrefix : '';
+  handleOTPOrKeypress(prefix + 'x'.repeat(32));
 }
 
 function simulateKeyB() {
-  handleOTPOrKeypress(CONFIG.KEY_B_PREFIX + 'x'.repeat(32));
+  const keyBUser = CONFIG.ROSTER.find(r => r.id === CONFIG.KEY_B_USER_ID);
+  const prefix = keyBUser ? keyBUser.keyPrefix : '';
+  handleOTPOrKeypress(prefix + 'x'.repeat(32));
 }
 
 // ---- Lockdown continue button ------------------------------
 function lockdownContinue() {
   playSound('beep');
+  if (!isStageEnabled(1)) { keyAAuthenticated = true; enterStage2(); return; }
   enterStage1();
 }
 

--- a/assets/js/escape-room.js
+++ b/assets/js/escape-room.js
@@ -37,6 +37,9 @@ function pickCredential() {
 
   const codeEl = document.getElementById('session-code-value');
   if (codeEl) codeEl.textContent = sessionCode;
+
+  const emailEl = document.getElementById('login-email');
+  if (emailEl) emailEl.value = activeCredential ? activeCredential.email : '';
 }
 
 // ---- Init --------------------------------------------------
@@ -142,7 +145,7 @@ function handleLogin() {
   const pass  = passEl.value;
 
   // Wrong credentials — show error and stay on login
-  if (email !== activeCredential.email || pass !== activeCredential.password) {
+  if (email !== activeCredential.email || pass.toLowerCase() !== activeCredential.password.toLowerCase()) {
     errEl.textContent = "Authentication failed. Check your credentials.";
     passEl.value = '';
     passEl.focus();
@@ -257,8 +260,11 @@ function enterStage4() {
   setSlotState('slot-a', 'authenticated', '✓ AUTHENTICATED');
   setSlotState('slot-b', 'waiting', 'INSERT KEY B');
 
+  const keyBUser = CONFIG.ROSTER.find(r => r.id === CONFIG.KEY_B_USER_ID);
   const hint = document.getElementById('stage4-hint');
-  if (hint) hint.textContent = CONFIG.KEY_B_HINT;
+  if (hint && keyBUser) {
+    hint.innerHTML = `The rollback requires countersignature from an <strong style="color:var(--amber);">${keyBUser.dept}</strong>.<br>Find the YubiKey for that role somewhere around the workstation.`;
+  }
 
   const demoBtn = document.getElementById('demo-key-b');
   if (demoBtn) demoBtn.style.display = CONFIG.YUBIKEY_REQUIRED ? 'none' : 'block';
@@ -312,13 +318,11 @@ function resetGame() {
   secondsLeft = CONFIG.TIMER_SECONDS;
   pickCredential();
 
-  // Reset login form
-  const emailEl = document.getElementById('login-email');
-  const passEl  = document.getElementById('login-pass');
-  const errEl   = document.getElementById('login-error');
-  if (emailEl) emailEl.value = '';
-  if (passEl)  passEl.value  = '';
-  if (errEl)   errEl.textContent = '';
+  // Reset login form (email is re-populated by pickCredential above)
+  const passEl = document.getElementById('login-pass');
+  const errEl  = document.getElementById('login-error');
+  if (passEl) passEl.value       = '';
+  if (errEl)  errEl.textContent  = '';
 
   const panel = document.querySelector('.login-panel');
   if (panel) { panel.style.opacity = ''; panel.style.transition = ''; }

--- a/content/escape-room/_index.md
+++ b/content/escape-room/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Project Cerberus"
+description: "YubiKey escape room experience — Chippewa Valley Code Camp"
+layout: "escape-room"
+draft: false
+---

--- a/content/escape-room/admin.md
+++ b/content/escape-room/admin.md
@@ -1,0 +1,6 @@
+---
+title: "Cerberus Admin Panel"
+description: "Admin controls for Project Cerberus escape room"
+layout: "escape-admin"
+draft: false
+---

--- a/layouts/escape-room/baseof.html
+++ b/layouts/escape-room/baseof.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>{{ block "title" . }}CVCC Escape Room{{ end }}</title>
+  {{ block "head" . }}{{ end }}
+</head>
+<body>
+  {{ block "main" . }}{{ end }}
+
+  <div id="yubico-badge" aria-label="Powered by Yubico">
+    <span class="yubico-powered-label">POWERED BY</span>
+    <img src="/img/sponsors/yubico.png" alt="Yubico" class="yubico-logo-img" />
+  </div>
+</body>
+</html>

--- a/layouts/escape-room/escape-admin.html
+++ b/layouts/escape-room/escape-admin.html
@@ -1,0 +1,381 @@
+{{ define "title" }}CAMPFIRE — Admin Panel{{ end }}
+
+{{ define "head" }}
+  {{- with resources.Get "css/escape-room.css" }}
+    {{- if eq hugo.Environment "development" }}
+      <link rel="stylesheet" href="{{ .RelPermalink }}">
+    {{- else }}
+      {{- with . | minify | fingerprint }}
+        <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous">
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  <style>
+    /* ---- Admin-specific overrides ------------------------- */
+    body { overflow: auto; }
+    body::after { display: none; }
+
+    .admin-wrap {
+      max-width: 540px;
+      margin: 0 auto;
+      padding: 40px 20px 60px;
+    }
+    .admin-title {
+      font-size: 20px;
+      letter-spacing: 0.2em;
+      color: var(--amber);
+      margin-bottom: 4px;
+    }
+    .admin-sub {
+      font-size: 11px;
+      letter-spacing: 0.2em;
+      color: var(--green-dim);
+      margin-bottom: 32px;
+    }
+    .admin-section {
+      border: 1px solid #1a3a1a;
+      border-radius: 4px;
+      padding: 20px;
+      margin-bottom: 20px;
+      background: rgba(0,255,65,0.02);
+    }
+    .admin-section h2 {
+      font-size: 12px;
+      letter-spacing: 0.25em;
+      color: var(--green-dim);
+      margin-bottom: 16px;
+      text-transform: uppercase;
+    }
+    .admin-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 12px;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .admin-row:last-child { margin-bottom: 0; }
+    .admin-label {
+      font-size: 13px;
+      color: var(--white);
+      flex: 1;
+    }
+    .admin-value {
+      font-size: 13px;
+      color: var(--amber);
+      letter-spacing: 0.05em;
+      text-align: right;
+    }
+    .admin-input {
+      background: #0a0a0a;
+      border: 1px solid var(--green-dim);
+      border-radius: 2px;
+      color: var(--amber);
+      font-family: var(--font-mono);
+      font-size: 13px;
+      padding: 6px 10px;
+      width: 200px;
+      outline: none;
+    }
+    .admin-input:focus { border-color: var(--green); }
+
+    #pin-gate {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 60vh;
+      text-align: center;
+    }
+    #pin-gate h1 {
+      font-size: 18px;
+      letter-spacing: 0.2em;
+      color: var(--amber);
+      margin-bottom: 24px;
+    }
+    .pin-boxes {
+      display: flex;
+      gap: 12px;
+      margin-bottom: 20px;
+    }
+    .pin-box {
+      width: 48px;
+      height: 56px;
+      border: 2px solid var(--green-dim);
+      border-radius: 4px;
+      background: rgba(0,255,65,0.04);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 24px;
+      color: var(--green);
+    }
+    .pin-box.filled { border-color: var(--green); background: rgba(0,255,65,0.10); }
+    .pin-error { color: var(--red); font-size: 13px; min-height: 18px; }
+
+    .otp-capture-prefix {
+      color: var(--amber);
+      font-size: 15px;
+      letter-spacing: 0.1em;
+    }
+    .divider {
+      border: none;
+      border-top: 1px solid #1a3a1a;
+      margin: 28px 0;
+    }
+  </style>
+{{ end }}
+
+{{ define "main" }}
+
+<!-- PIN gate -->
+<div id="pin-gate">
+  <h1>⚙ ADMIN ACCESS</h1>
+  <p style="color: var(--green-dim); font-size: 12px; letter-spacing: 0.15em; margin-bottom: 24px;">
+    Enter admin PIN to continue
+  </p>
+  <div class="pin-boxes" id="pin-display">
+    <div class="pin-box" id="pd0"></div>
+    <div class="pin-box" id="pd1"></div>
+    <div class="pin-box" id="pd2"></div>
+    <div class="pin-box" id="pd3"></div>
+  </div>
+  <div class="pin-error" id="pin-error"></div>
+</div>
+
+<!-- Admin panel (hidden until PIN passed) -->
+<div id="admin-panel" style="display:none;">
+  <div class="admin-wrap">
+    <div class="admin-title">⚙ CAMPFIRE ADMIN</div>
+    <div class="admin-sub">CONFIGURATION &amp; RESET PANEL</div>
+
+    <div class="admin-section">
+      <h2>▸ Reset</h2>
+      <p style="font-size: 13px; color: var(--white); margin-bottom: 16px; line-height: 1.6;">
+        Use this between groups. Reloads the main game to the intro screen.<br>
+        Remember to re-hide Key B before the next group arrives.
+      </p>
+      <button class="btn" onclick="doReset()">↺ RESET GAME FOR NEXT GROUP</button>
+    </div>
+
+    <div class="admin-section">
+      <h2>▸ YubiKey Prefixes (read-only)</h2>
+      <p style="font-size: 12px; color: var(--green-dim); margin-bottom: 16px; line-height: 1.6;">
+        These are loaded from <code style="color:var(--amber);">config.js</code>.<br>
+        To change them, edit that file directly, then reload.
+      </p>
+      <div class="admin-row">
+        <span class="admin-label">Key A Prefix (Stage 1)</span>
+        <span class="admin-value" id="show-key-a">—</span>
+      </div>
+      <div class="admin-row">
+        <span class="admin-label">Key B Prefix (Stage 4)</span>
+        <span class="admin-value" id="show-key-b">—</span>
+      </div>
+      <div class="admin-row">
+        <span class="admin-label">Codeword (Stage 3)</span>
+        <span class="admin-value" id="show-codeword">—</span>
+      </div>
+      <div class="admin-row">
+        <span class="admin-label">Timer (seconds)</span>
+        <span class="admin-value" id="show-timer">—</span>
+      </div>
+    </div>
+
+    <div class="admin-section">
+      <h2>▸ Session Code Lookup</h2>
+      <p style="font-size: 12px; color: var(--green-dim); margin-bottom: 16px; line-height: 1.6;">
+        Find the session code in the bottom-left corner of the game screen.<br>
+        Enter it below to reveal which credentials are active for that session.
+      </p>
+      <div style="display:flex; gap:10px; align-items:center; margin-bottom:16px;">
+        <input id="session-lookup-input" class="admin-input"
+               type="text" maxlength="1" placeholder="A"
+               autocomplete="off" autocorrect="off" autocapitalize="characters"
+               style="width:60px; text-align:center; font-size:22px; letter-spacing:0.1em;" />
+        <button class="btn" onclick="lookupSession()">LOOK UP</button>
+      </div>
+      <div id="session-lookup-result"></div>
+    </div>
+
+    <div class="admin-section">
+      <h2>▸ Live OTP Capture</h2>
+      <p style="font-size: 12px; color: var(--green-dim); margin-bottom: 12px; line-height: 1.6;">
+        Click the box below, then touch a YubiKey to capture its OTP prefix.<br>
+        Copy the first 12 characters into <code style="color:var(--amber);">config.js</code>.
+      </p>
+
+      <div style="margin-bottom: 12px;">
+        <label style="font-size: 11px; letter-spacing: 0.15em; color: var(--green-dim); display:block; margin-bottom: 6px;">
+          KEY LABEL (optional)
+        </label>
+        <input id="otp-label" class="admin-input" type="text"
+               placeholder="e.g. Key A" autocomplete="off" style="width: 160px;" />
+      </div>
+
+      <p style="font-size: 12px; color: var(--amber); margin-bottom: 8px;">
+        Click here then touch the key:
+      </p>
+      <input id="otp-capture-input" class="admin-input"
+             type="text" autocomplete="off" autocorrect="off"
+             autocapitalize="none" spellcheck="false"
+             placeholder="(click here, then touch key)"
+             style="width: 100%; margin-bottom: 12px;" />
+
+      <div id="otp-results"></div>
+    </div>
+
+    <div class="admin-section">
+      <h2>▸ Pre-Event Checklist</h2>
+      <ol style="font-size: 13px; color: var(--white); line-height: 2; padding-left: 20px;">
+        <li>Capture OTP prefixes for each YubiKey using the tool above.</li>
+        <li>Update <code style="color:var(--amber);">static/escape-room/config.js</code> with <code style="color:var(--amber);">KEY_A_PREFIX</code> and <code style="color:var(--amber);">KEY_B_PREFIX</code>.</li>
+        <li>Confirm <code style="color:var(--amber);">CODEWORD</code> and <code style="color:var(--amber);">ENCODED_MESSAGE</code> match in config.</li>
+        <li>Print Volunteer Roster and Cipher Wheel props.</li>
+        <li>Label YubiKeys with volunteer names.</li>
+        <li>Hide Key B (under table, lockbox, envelope).</li>
+        <li>Put sticky note with credentials on the desk.</li>
+        <li>Open the game URL in Safari, set to fullscreen (Guided Access).</li>
+        <li>Test full run-through with a volunteer.</li>
+      </ol>
+    </div>
+
+    <hr class="divider" />
+
+    <div style="text-align: center;">
+      <a href="/escape-room/" class="btn btn-amber">← BACK TO GAME</a>
+    </div>
+  </div>
+</div>
+
+<script src="/escape-room/config.js"></script>
+<script>
+let pinBuffer = '';
+
+document.addEventListener('keydown', handlePinKey);
+
+function handlePinKey(e) {
+  if (document.getElementById('pin-gate').style.display === 'none') return;
+  if (e.target === document.getElementById('otp-capture-input')) return;
+
+  if (/^[0-9]$/.test(e.key) && pinBuffer.length < 4) {
+    pinBuffer += e.key;
+    updatePinDisplay();
+    if (pinBuffer.length === 4) setTimeout(checkPin, 100);
+  } else if (e.key === 'Backspace') {
+    pinBuffer = pinBuffer.slice(0, -1);
+    updatePinDisplay();
+    document.getElementById('pin-error').textContent = '';
+  }
+}
+
+function updatePinDisplay() {
+  for (let i = 0; i < 4; i++) {
+    const box = document.getElementById(`pd${i}`);
+    const filled = i < pinBuffer.length;
+    box.textContent = filled ? '●' : '';
+    box.classList.toggle('filled', filled);
+  }
+}
+
+function checkPin() {
+  if (pinBuffer === CONFIG.ADMIN_PIN) {
+    document.getElementById('pin-gate').style.display = 'none';
+    document.getElementById('admin-panel').style.display = 'block';
+    loadAdminValues();
+    document.removeEventListener('keydown', handlePinKey);
+  } else {
+    document.getElementById('pin-error').textContent = '✗ Incorrect PIN';
+    pinBuffer = '';
+    updatePinDisplay();
+    setTimeout(() => { document.getElementById('pin-error').textContent = ''; }, 1500);
+  }
+}
+
+function loadAdminValues() {
+  setText('show-key-a',    CONFIG.KEY_A_PREFIX  || '(not set)');
+  setText('show-key-b',    CONFIG.KEY_B_PREFIX  || '(not set)');
+  setText('show-codeword', CONFIG.CODEWORD      || '(not set)');
+  setText('show-timer',    CONFIG.TIMER_SECONDS + 's (' + Math.floor(CONFIG.TIMER_SECONDS/60) + ' min)');
+}
+
+function setText(id, val) {
+  const el = document.getElementById(id);
+  if (el) el.textContent = val;
+}
+
+function lookupSession() {
+  const input = document.getElementById('session-lookup-input');
+  const resultEl = document.getElementById('session-lookup-result');
+  const code = input.value.trim().toUpperCase();
+  const idx = code.charCodeAt(0) - 65; // A→0, B→1, C→2, D→3
+  const creds = CONFIG.LOGIN_CREDENTIALS;
+
+  if (!code || isNaN(idx) || idx < 0 || idx >= creds.length) {
+    resultEl.innerHTML = '<div style="color:var(--red);font-size:13px;">✗ Invalid session code. Enter A, B, C, or D.</div>';
+    return;
+  }
+
+  const cred = creds[idx];
+  resultEl.innerHTML = `
+    <div style="border:1px solid #1a3a1a; border-radius:3px; padding:12px 14px;">
+      <div style="font-size:10px; color:var(--green-dim); letter-spacing:0.15em; margin-bottom:12px;">
+        SESSION ${code} — ACTIVE CREDENTIALS
+      </div>
+      <div class="admin-row">
+        <span class="admin-label">Name</span>
+        <span class="admin-value">${cred.name}</span>
+      </div>
+      <div class="admin-row">
+        <span class="admin-label">Email</span>
+        <span class="admin-value">${cred.email}</span>
+      </div>
+      <div class="admin-row" style="margin-bottom:0;">
+        <span class="admin-label">Password</span>
+        <span class="admin-value">${cred.password}</span>
+      </div>
+    </div>
+  `;
+}
+
+const otpInput = document.getElementById('otp-capture-input');
+const otpResults = document.getElementById('otp-results');
+let captureHistory = [];
+
+otpInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    const otp = otpInput.value.trim();
+    otpInput.value = '';
+    if (otp.length >= 12) {
+      const label = document.getElementById('otp-label').value.trim() || 'Key';
+      const prefix = otp.slice(0, 12);
+      captureHistory.unshift({ label, prefix, full: otp, ts: new Date().toLocaleTimeString() });
+      renderCaptureHistory();
+    }
+  }
+});
+
+function renderCaptureHistory() {
+  if (captureHistory.length === 0) { otpResults.innerHTML = ''; return; }
+  otpResults.innerHTML = captureHistory.map(entry => `
+    <div style="margin-bottom:12px; border: 1px solid #1a3a1a; border-radius:3px; padding: 10px 14px;">
+      <div style="font-size:10px; color: var(--green-dim); letter-spacing:0.15em; margin-bottom:4px;">
+        ${entry.ts} — ${entry.label}
+      </div>
+      <div style="font-size:11px; color:#446644; margin-bottom:4px;">Full OTP:</div>
+      <div style="font-size:12px; color: #667766; word-break:break-all; margin-bottom:8px;">${entry.full}</div>
+      <div style="font-size:11px; color:#446644; margin-bottom:4px;">PREFIX (first 12 chars — copy this):</div>
+      <div class="otp-capture-prefix">${entry.prefix}</div>
+    </div>
+  `).join('');
+}
+
+function doReset() {
+  if (confirm('Reset game? This will navigate to /escape-room/.')) {
+    window.location.href = '/escape-room/';
+  }
+}
+</script>
+
+{{ end }}

--- a/layouts/escape-room/escape-admin.html
+++ b/layouts/escape-room/escape-admin.html
@@ -119,6 +119,22 @@
       font-size: 15px;
       letter-spacing: 0.1em;
     }
+    .copy-prefix-btn {
+      margin-left: 12px;
+      padding: 3px 10px;
+      border: 1px solid var(--amber-dim);
+      border-radius: 2px;
+      background: transparent;
+      color: var(--amber-dim);
+      font-family: var(--font-mono);
+      font-size: 10px;
+      letter-spacing: 0.15em;
+      cursor: pointer;
+      vertical-align: middle;
+      transition: background 0.15s, color 0.15s;
+    }
+    .copy-prefix-btn:hover { background: var(--amber-dim); color: #000; }
+    .copy-prefix-btn.copied { border-color: var(--green); color: var(--green); }
 
     /* ---- Stage toggle switches ----------------------------- */
     .toggle-switch {
@@ -498,17 +514,30 @@ otpInput.addEventListener('keydown', (e) => {
 
 function renderCaptureHistory() {
   if (captureHistory.length === 0) { otpResults.innerHTML = ''; return; }
-  otpResults.innerHTML = captureHistory.map(entry => `
+  otpResults.innerHTML = captureHistory.map((entry, i) => `
     <div style="margin-bottom:12px; border: 1px solid #1a3a1a; border-radius:3px; padding: 10px 14px;">
       <div style="font-size:10px; color: var(--green-dim); letter-spacing:0.15em; margin-bottom:4px;">
         ${entry.ts} — ${entry.label}
       </div>
       <div style="font-size:11px; color:#446644; margin-bottom:4px;">Full OTP:</div>
       <div style="font-size:12px; color: #667766; word-break:break-all; margin-bottom:8px;">${entry.full}</div>
-      <div style="font-size:11px; color:#446644; margin-bottom:4px;">PREFIX (first 12 chars — copy this):</div>
-      <div class="otp-capture-prefix">${entry.prefix}</div>
+      <div style="font-size:11px; color:#446644; margin-bottom:4px;">PREFIX (first 12 chars):</div>
+      <div style="display:flex; align-items:center; gap:8px;">
+        <span class="otp-capture-prefix">${entry.prefix}</span>
+        <button class="copy-prefix-btn" id="copy-btn-${i}" onclick="copyPrefix('${entry.prefix}', ${i})">COPY</button>
+      </div>
     </div>
   `).join('');
+}
+
+function copyPrefix(prefix, idx) {
+  navigator.clipboard.writeText(prefix).then(() => {
+    const btn = document.getElementById(`copy-btn-${idx}`);
+    if (!btn) return;
+    btn.textContent = '✓ COPIED';
+    btn.classList.add('copied');
+    setTimeout(() => { btn.textContent = 'COPY'; btn.classList.remove('copied'); }, 2000);
+  });
 }
 
 function doReset() {

--- a/layouts/escape-room/escape-admin.html
+++ b/layouts/escape-room/escape-admin.html
@@ -119,6 +119,54 @@
       font-size: 15px;
       letter-spacing: 0.1em;
     }
+
+    /* ---- Stage toggle switches ----------------------------- */
+    .toggle-switch {
+      position: relative;
+      display: inline-block;
+      width: 44px;
+      height: 24px;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+    .toggle-switch input {
+      opacity: 0; width: 0; height: 0; position: absolute;
+    }
+    .toggle-track {
+      position: absolute;
+      inset: 0;
+      border: 1px solid var(--green-dim);
+      border-radius: 12px;
+      background: #0a0a0a;
+      transition: background 0.2s, border-color 0.2s;
+    }
+    .toggle-track::after {
+      content: '';
+      position: absolute;
+      top: 3px;
+      left: 3px;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: #333;
+      transition: transform 0.2s, background 0.2s;
+    }
+    .toggle-switch input:checked + .toggle-track {
+      border-color: var(--green);
+      background: rgba(0,255,65,0.08);
+    }
+    .toggle-switch input:checked + .toggle-track::after {
+      transform: translateX(20px);
+      background: var(--amber);
+    }
+    .stage-toggle-status {
+      font-size: 11px;
+      letter-spacing: 0.12em;
+      width: 56px;
+      text-align: right;
+      flex-shrink: 0;
+    }
+
     .divider {
       border: none;
       border-top: 1px solid #1a3a1a;
@@ -162,18 +210,11 @@
     <div class="admin-section">
       <h2>▸ YubiKey Prefixes (read-only)</h2>
       <p style="font-size: 12px; color: var(--green-dim); margin-bottom: 16px; line-height: 1.6;">
-        These are loaded from <code style="color:var(--amber);">config.js</code>.<br>
-        To change them, edit that file directly, then reload.
+        Prefixes are stored per-user in <code style="color:var(--amber);">config.js</code> → <code style="color:var(--amber);">ROSTER</code>.<br>
+        Use the Live OTP Capture tool below to find a prefix, then edit the file directly.
       </p>
-      <div class="admin-row">
-        <span class="admin-label">Key A Prefix (Stage 1)</span>
-        <span class="admin-value" id="show-key-a">—</span>
-      </div>
-      <div class="admin-row">
-        <span class="admin-label">Key B Prefix (Stage 4)</span>
-        <span class="admin-value" id="show-key-b">—</span>
-      </div>
-      <div class="admin-row">
+      <div id="roster-prefix-list"></div>
+      <div class="admin-row" style="margin-top: 12px;">
         <span class="admin-label">Codeword (Stage 3)</span>
         <span class="admin-value" id="show-codeword">—</span>
       </div>
@@ -227,10 +268,58 @@
     </div>
 
     <div class="admin-section">
+      <h2>▸ Stage Toggles</h2>
+      <p style="font-size: 12px; color: var(--green-dim); margin-bottom: 16px; line-height: 1.6;">
+        Disable stages to skip them during play. Useful for demos or shortened runs.<br>
+        Settings are saved in this browser and persist across sessions.
+      </p>
+      <div class="admin-row">
+        <span class="admin-label">Stage 0 — Login</span>
+        <span class="stage-toggle-status" id="status-s0">ENABLED</span>
+        <label class="toggle-switch">
+          <input type="checkbox" id="toggle-s0" onchange="saveStageToggles()">
+          <span class="toggle-track"></span>
+        </label>
+      </div>
+      <div class="admin-row">
+        <span class="admin-label">Stage 1 — Identify committer (Key A)</span>
+        <span class="stage-toggle-status" id="status-s1">ENABLED</span>
+        <label class="toggle-switch">
+          <input type="checkbox" id="toggle-s1" onchange="saveStageToggles()">
+          <span class="toggle-track"></span>
+        </label>
+      </div>
+      <div class="admin-row">
+        <span class="admin-label">Stage 2 — Decrypt cipher</span>
+        <span class="stage-toggle-status" id="status-s2">ENABLED</span>
+        <label class="toggle-switch">
+          <input type="checkbox" id="toggle-s2" onchange="saveStageToggles()">
+          <span class="toggle-track"></span>
+        </label>
+      </div>
+      <div class="admin-row">
+        <span class="admin-label">Stage 3 — Enter codeword</span>
+        <span class="stage-toggle-status" id="status-s3">ENABLED</span>
+        <label class="toggle-switch">
+          <input type="checkbox" id="toggle-s3" onchange="saveStageToggles()">
+          <span class="toggle-track"></span>
+        </label>
+      </div>
+      <div class="admin-row">
+        <span class="admin-label">Stage 4 — Dual auth (Key B)</span>
+        <span class="stage-toggle-status" id="status-s4">ENABLED</span>
+        <label class="toggle-switch">
+          <input type="checkbox" id="toggle-s4" onchange="saveStageToggles()">
+          <span class="toggle-track"></span>
+        </label>
+      </div>
+    </div>
+
+    <div class="admin-section">
       <h2>▸ Pre-Event Checklist</h2>
       <ol style="font-size: 13px; color: var(--white); line-height: 2; padding-left: 20px;">
-        <li>Capture OTP prefixes for each YubiKey using the tool above.</li>
-        <li>Update <code style="color:var(--amber);">static/escape-room/config.js</code> with <code style="color:var(--amber);">KEY_A_PREFIX</code> and <code style="color:var(--amber);">KEY_B_PREFIX</code>.</li>
+        <li>Capture OTP prefixes for each YubiKey using the Live OTP Capture tool above.</li>
+        <li>Update <code style="color:var(--amber);">static/escape-room/config.js</code> → each user's <code style="color:var(--amber);">keyPrefix</code> in <code style="color:var(--amber);">ROSTER</code>.</li>
         <li>Confirm <code style="color:var(--amber);">CODEWORD</code> and <code style="color:var(--amber);">ENCODED_MESSAGE</code> match in config.</li>
         <li>Print Volunteer Roster and Cipher Wheel props.</li>
         <li>Label YubiKeys with volunteer names.</li>
@@ -294,10 +383,60 @@ function checkPin() {
 }
 
 function loadAdminValues() {
-  setText('show-key-a',    CONFIG.KEY_A_PREFIX  || '(not set)');
-  setText('show-key-b',    CONFIG.KEY_B_PREFIX  || '(not set)');
   setText('show-codeword', CONFIG.CODEWORD      || '(not set)');
   setText('show-timer',    CONFIG.TIMER_SECONDS + 's (' + Math.floor(CONFIG.TIMER_SECONDS/60) + ' min)');
+
+  const listEl = document.getElementById('roster-prefix-list');
+  if (listEl) {
+    listEl.innerHTML = CONFIG.ROSTER.map(r => {
+      const isKeyB = r.id === CONFIG.KEY_B_USER_ID;
+      const role   = isKeyB ? ' <span style="color:var(--amber);font-size:10px;">KEY B (Stage 4)</span>'
+                            : ' <span style="color:var(--green-dim);font-size:10px;">Stage 1 eligible</span>';
+      return `
+        <div class="admin-row">
+          <span class="admin-label">${r.firstName} ${r.lastName} — ${r.id}${role}</span>
+          <span class="admin-value">${r.keyPrefix || '<span style="color:#555;">(not set)</span>'}</span>
+        </div>`;
+    }).join('');
+  }
+
+  loadStageToggles();
+}
+
+function loadStageToggles() {
+  let cfg = null;
+  try {
+    const stored = localStorage.getItem('campfire_stages');
+    if (stored) cfg = JSON.parse(stored);
+  } catch (e) {}
+  ['s0','s1','s2','s3','s4'].forEach(s => {
+    const cb = document.getElementById(`toggle-${s}`);
+    if (!cb) return;
+    // localStorage takes precedence; fall back to CONFIG.STAGES_ENABLED defaults
+    if (cfg) {
+      cb.checked = cfg[s] !== false;
+    } else {
+      cb.checked = CONFIG.STAGES_ENABLED ? CONFIG.STAGES_ENABLED[s] !== false : true;
+    }
+    updateStageStatusLabel(s, cb.checked);
+  });
+}
+
+function saveStageToggles() {
+  const cfg = {};
+  ['s0','s1','s2','s3','s4'].forEach(s => {
+    const cb = document.getElementById(`toggle-${s}`);
+    cfg[s] = cb ? cb.checked : true;
+    updateStageStatusLabel(s, cfg[s]);
+  });
+  localStorage.setItem('campfire_stages', JSON.stringify(cfg));
+}
+
+function updateStageStatusLabel(s, enabled) {
+  const el = document.getElementById(`status-${s}`);
+  if (!el) return;
+  el.textContent = enabled ? 'ENABLED' : 'SKIPPED';
+  el.style.color  = enabled ? 'var(--green-dim)' : 'var(--red)';
 }
 
 function setText(id, val) {
@@ -309,15 +448,16 @@ function lookupSession() {
   const input = document.getElementById('session-lookup-input');
   const resultEl = document.getElementById('session-lookup-result');
   const code = input.value.trim().toUpperCase();
-  const idx = code.charCodeAt(0) - 65; // A→0, B→1, C→2, D→3
-  const creds = CONFIG.LOGIN_CREDENTIALS;
+  const idx = code.charCodeAt(0) - 65; // A→0, B→1, C→2, …
+  const eligible = CONFIG.ROSTER.filter(r => r.id !== CONFIG.KEY_B_USER_ID && r.keyPrefix);
 
-  if (!code || isNaN(idx) || idx < 0 || idx >= creds.length) {
-    resultEl.innerHTML = '<div style="color:var(--red);font-size:13px;">✗ Invalid session code. Enter A, B, C, or D.</div>';
+  if (!code || isNaN(idx) || idx < 0 || idx >= eligible.length) {
+    const last = String.fromCharCode(65 + eligible.length - 1);
+    resultEl.innerHTML = `<div style="color:var(--red);font-size:13px;">✗ Invalid session code. Enter A–${last}.</div>`;
     return;
   }
 
-  const cred = creds[idx];
+  const user = eligible[idx];
   resultEl.innerHTML = `
     <div style="border:1px solid #1a3a1a; border-radius:3px; padding:12px 14px;">
       <div style="font-size:10px; color:var(--green-dim); letter-spacing:0.15em; margin-bottom:12px;">
@@ -325,15 +465,15 @@ function lookupSession() {
       </div>
       <div class="admin-row">
         <span class="admin-label">Name</span>
-        <span class="admin-value">${cred.name}</span>
+        <span class="admin-value">${user.name}</span>
       </div>
       <div class="admin-row">
         <span class="admin-label">Email</span>
-        <span class="admin-value">${cred.email}</span>
+        <span class="admin-value">${user.email}</span>
       </div>
       <div class="admin-row" style="margin-bottom:0;">
         <span class="admin-label">Password</span>
-        <span class="admin-value">${cred.password}</span>
+        <span class="admin-value">${user.password}</span>
       </div>
     </div>
   `;

--- a/layouts/escape-room/escape-room.html
+++ b/layouts/escape-room/escape-room.html
@@ -1,0 +1,301 @@
+{{ define "title" }}CVCC: OPERATION HOTFIX — CAMPFIRE Terminal{{ end }}
+
+{{ define "head" }}
+  {{- with resources.Get "css/escape-room.css" }}
+    {{- if eq hugo.Environment "development" }}
+      <link rel="stylesheet" href="{{ .RelPermalink }}">
+    {{- else }}
+      {{- with . | minify | fingerprint }}
+        <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous">
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{ end }}
+
+{{ define "main" }}
+
+<!-- HIDDEN YUBIKEY INPUT -->
+<input id="yubikey-input" type="text" autocomplete="off" autocorrect="off"
+       autocapitalize="none" spellcheck="false" aria-hidden="true" tabindex="-1" />
+
+<!-- SESSION CODE (bottom-left, for volunteer/admin reference) -->
+<div id="session-code-display">
+  SESSION <span id="session-code-value">—</span>
+</div>
+
+<!-- HUD -->
+<div id="hud">
+  <span id="hud-stage">● STAGE 1</span>
+  <span id="hud-timer">T-05:00</span>
+  <span style="color: var(--green-dim); font-size:11px; letter-spacing:0.1em;">CAMPFIRE</span>
+</div>
+
+<!-- SCREEN: INTRO -->
+<div id="screen-intro" class="screen active">
+  <div class="cerberus-logo">◈ CVCC: OPERATION HOTFIX ◈</div>
+  <div class="cerberus-sub">CHIPPEWA VALLEY CODE CAMP — VOLUNTEER PORTAL</div>
+
+  <div class="intro-box">
+    <p>You're at a volunteer workstation inside <strong>CVTC Business Campus</strong> —<br>
+       home of the 14th annual Chippewa Valley Code Camp.</p>
+    <p>Someone left their credentials on a <strong>sticky note</strong> next to the keyboard.</p>
+    <p>You log in — and <strong>CAMPFIRE</strong> flags a crisis.<br>
+       Someone force-pushed <code style="color:var(--amber);">"fix schedule typo"</code> to <code style="color:var(--amber);">main</code>.<br>
+       Brian Hogan's keynote, 47 sessions, and 200+ registrations are at risk.</p>
+    <p style="color: var(--green-dim); font-size: 13px; margin-top: 8px;">
+      CAMPFIRE has locked the pipeline. You have <strong style="color:var(--white);">5 minutes</strong> to authenticate the rollback.<br>
+      <strong style="color: var(--amber);">CAMPFIRE doesn't trust passwords. Only hardware keys.</strong>
+    </p>
+  </div>
+
+  <button class="btn" onclick="beginMission()">▶ BEGIN MISSION</button>
+  <p class="text-dim mt-12" style="font-size: 11px; letter-spacing: 0.15em;">
+    FIND THE STICKY NOTE ON THE DESK
+  </p>
+</div>
+
+<!-- SCREEN: STAGE 0 — Login -->
+<div id="screen-stage0" class="screen">
+  <div class="login-panel">
+    <div class="login-logo">CAMPFIRE</div>
+    <div class="login-tagline">CVCC VOLUNTEER PORTAL 2026 — SECURE ACCESS</div>
+
+    <form id="login-form" autocomplete="off">
+      <div class="login-field">
+        <label for="login-email">Email Address</label>
+        <input id="login-email" type="email" placeholder="volunteer@cvcc.dev"
+               autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false" />
+      </div>
+      <div class="login-field">
+        <label for="login-pass">Password</label>
+        <input id="login-pass" type="password" placeholder="••••••••••" autocomplete="off" />
+      </div>
+      <button type="submit" class="login-submit">SIGN IN →</button>
+      <div id="login-error" class="login-error"></div>
+    </form>
+  </div>
+</div>
+
+<!-- SCREEN: LOCKDOWN -->
+<div id="screen-lockdown" class="screen lockdown-alert">
+  <div class="alert-icon">⚠</div>
+  <div class="alert-title">UNAUTHORIZED PUSH DETECTED</div>
+  <div class="alert-sub">
+    CAMPFIRE LOCKDOWN INITIATED<br>
+    FORCE-PUSH TO cvcc-2026/schedule-app<br>
+    KEYNOTE + 47 SESSIONS + 200+ REGISTRATIONS AT RISK<br>
+    <br>
+    <span style="font-size: 18px; color: var(--red); letter-spacing: 0.2em;" class="blink">
+      HARDWARE AUTHENTICATION REQUIRED TO ROLLBACK
+    </span>
+  </div>
+  <button class="btn btn-red" onclick="lockdownContinue()">► ACCESS CAMPFIRE TERMINAL</button>
+  <p style="color:#ff6666; font-size: 11px; margin-top: 16px; letter-spacing: 0.1em;">
+    TIMER HAS STARTED — ACT IMMEDIATELY
+  </p>
+</div>
+
+<!-- SCREEN: STAGE 1 -->
+<div id="screen-stage1" class="screen">
+  <div class="stage-panel">
+    <div class="stage-label">STAGE 01 / 04</div>
+    <div class="stage-title">IDENTIFY THE COMMITTER</div>
+
+    <div class="terminal-block">
+<span class="term-prompt">campfire@cvcc:~$</span> git log --oneline -1 cvcc-2026/schedule-app
+<span class="term-error">FLAGGED: d3a9<span class="term-value" id="stage1-fp">...gnlr</span> (HEAD -> main) "fix schedule typo"</span>
+<span class="term-prompt">campfire@cvcc:~$</span> campfire verify --suffix <span class="term-value" id="stage1-fp-echo">...gnlr</span>
+ALERT: Unverified push. Brian Hogan keynote + 47 sessions at risk.
+Authenticate volunteer lead to initiate rollback.
+<span class="blink term-prompt">_</span>
+    </div>
+
+    <div class="stage-body">
+      Check the <strong>CVCC VOLUNTEER ROSTER</strong> card on the desk.<br>
+      Find the volunteer whose key suffix matches the commit token above.<br>
+      Pick up <strong>their labeled YubiKey</strong>, plug it in, and <strong>touch the gold contact</strong>.
+    </div>
+
+    <div id="stage1-status" class="status-msg info">
+      Plug in the correct YubiKey and touch it.
+    </div>
+
+    <div id="demo-key-a" style="display:none; margin-top:16px; padding:12px 16px; border:1px dashed var(--amber); border-radius:4px; text-align:center;">
+      <div style="font-size:10px; letter-spacing:0.2em; color:var(--amber); margin-bottom:10px;">⚠ DEMO MODE — NO YUBIKEY CONNECTED</div>
+      <button class="btn btn-amber" onclick="simulateKeyA()">▶ SIMULATE YUBIKEY TOUCH (KEY A)</button>
+    </div>
+  </div>
+</div>
+
+<!-- SCREEN: STAGE 2 -->
+<div id="screen-stage2" class="screen">
+  <div class="stage-panel">
+    <div class="stage-label">STAGE 02 / 04</div>
+    <div class="stage-title">DECRYPT THE ROLLBACK CODE</div>
+
+    <div class="terminal-block">
+<span class="term-prompt">campfire@cvcc:~$</span> campfire auth --accept
+✓ Token verified. Volunteer identity confirmed.
+Decrypting rollback authorization for cvcc-2026/schedule-app...
+    </div>
+
+    <div class="cipher-display">
+      <div class="cipher-label">// ENCRYPTED ROLLBACK AUTHORIZATION — CVCC-2026 //</div>
+      <div class="cipher-encoded" id="stage2-encoded">WKH FRGH LV: GHOWD</div>
+      <div class="cipher-hint">Encoding: ROT-3 cipher — use the cipher wheel on the desk</div>
+    </div>
+
+    <div class="stage-body">
+      Use the <strong>ROT-3 Cipher Wheel</strong> on the desk to decode the message.<br>
+      Each letter has been shifted forward by <strong>3 positions</strong>.<br>
+      The decoded result is a <strong>5-letter codeword</strong> — remember it for the next step.
+    </div>
+
+    <button class="btn" onclick="stage2Continue()">► I HAVE THE CODEWORD</button>
+  </div>
+</div>
+
+<!-- SCREEN: STAGE 3 -->
+<div id="screen-stage3" class="screen">
+  <div class="stage-panel">
+    <div class="stage-label">STAGE 03 / 04</div>
+    <div class="stage-title">ENTER THE CODEWORD</div>
+
+    <div class="cipher-display" style="margin-bottom: 16px;">
+      <div class="cipher-label">// ROLLBACK AUTHORIZATION TO DECODE //</div>
+      <div class="cipher-encoded" id="stage3-encoded-ref"></div>
+      <div class="cipher-hint">ROT-3 — shift each letter back 3 positions</div>
+    </div>
+
+    <div class="stage-body">
+      Type the 5-letter decoded codeword using the keyboard.<br>
+      <span class="text-dim">Letters only — press Backspace to correct.</span>
+    </div>
+
+    <div class="code-input-row">
+      <div class="code-char-box" id="char-0"></div>
+      <div class="code-char-box" id="char-1"></div>
+      <div class="code-char-box" id="char-2"></div>
+      <div class="code-char-box" id="char-3"></div>
+      <div class="code-char-box" id="char-4"></div>
+    </div>
+
+    <div id="stage3-status" class="status-msg info">
+      Type the decoded codeword on the keyboard.
+    </div>
+  </div>
+</div>
+
+<!-- SCREEN: STAGE 4 -->
+<div id="screen-stage4" class="screen">
+  <div class="stage-panel">
+    <div class="stage-label">STAGE 04 / 04</div>
+    <div class="stage-title">DUAL AUTHENTICATION REQUIRED</div>
+
+    <div class="terminal-block">
+<span class="term-prompt">campfire@cvcc:~$</span> git rollback --stage cvcc-2026/schedule-app
+Rollback partially staged. Dual authentication required.
+Awaiting secondary volunteer token...
+<span class="blink term-prompt">_</span>
+    </div>
+
+    <div class="key-slots">
+      <div class="key-slot authenticated" id="slot-a">
+        <div class="key-slot-icon">🔑</div>
+        <div class="key-slot-label">PRIMARY KEY</div>
+        <div class="key-slot-status">✓ AUTHENTICATED</div>
+      </div>
+      <div class="key-slot waiting" id="slot-b">
+        <div class="key-slot-icon">🔐</div>
+        <div class="key-slot-label">SECONDARY KEY</div>
+        <div class="key-slot-status">INSERT KEY B</div>
+      </div>
+    </div>
+
+    <div class="stage-body" id="stage4-hint" style="white-space: pre-line;"></div>
+
+    <div id="stage4-status" class="status-msg info">
+      Locate Key B and plug it in, then touch it.
+    </div>
+
+    <div id="demo-key-b" style="display:none; margin-top:16px; padding:12px 16px; border:1px dashed var(--amber); border-radius:4px; text-align:center;">
+      <div style="font-size:10px; letter-spacing:0.2em; color:var(--amber); margin-bottom:10px;">⚠ DEMO MODE — NO YUBIKEY CONNECTED</div>
+      <button class="btn btn-amber" onclick="simulateKeyB()">▶ SIMULATE YUBIKEY TOUCH (KEY B)</button>
+    </div>
+  </div>
+</div>
+
+<!-- SCREEN: WIN -->
+<div id="screen-win" class="screen">
+  <div class="win-box">
+    <div class="win-title">█ ROLLBACK COMPLETE █</div>
+    <div class="win-sub">CAMPFIRE: DISARMED — CVCC 2026 SYSTEMS RESTORED</div>
+
+    <div class="win-time" id="win-time">Time remaining: --:--</div>
+
+    <div class="win-message">
+      Brian Hogan's keynote is back online.<br>
+      All 47 sessions and 200+ registrations restored.<br>
+      <br>
+      <span class="text-dim" style="font-size: 12px;">
+        This is why hardware keys exist — a sticky note on a keyboard<br>
+        can take down a live conference app. A hardware key can't.
+      </span>
+    </div>
+
+    <div class="win-qr" id="win-qr" title="Scan to learn more about YubiKey">
+      <span style="font-size: 9px; line-height: 1.4;">
+        QR CODE<br>yubico.com<br>
+        <small>(replace with actual QR image)</small>
+      </span>
+    </div>
+
+    <button class="btn mt-12" onclick="resetGame()">↺ RESET FOR NEXT GROUP</button>
+  </div>
+</div>
+
+<!-- SCREEN: FAIL -->
+<div id="screen-fail" class="screen">
+  <div class="alert-icon" style="color: var(--red);">✗</div>
+  <div class="fail-title">ROLLBACK FAILED</div>
+  <div class="fail-sub">
+    CAMPFIRE: LOCKDOWN MAINTAINED<br>
+    CVCC 2026 SCHEDULE APP: OFFLINE<br>
+    BRIAN HOGAN'S KEYNOTE: GONE<br>
+    <br>
+    <span style="font-size: 13px; color: #cc7777;">
+      A sticky note on a keyboard took down the whole conference.<br>
+      A hardware key could have stopped it.
+    </span>
+  </div>
+  <button class="btn btn-red" onclick="resetGame()">↺ TRY AGAIN</button>
+</div>
+
+<!-- config.js is a plain static file so volunteers can edit it without a rebuild -->
+<script src="/escape-room/config.js"></script>
+
+{{- with resources.Get "js/escape-room.js" }}
+  {{- if eq hugo.Environment "development" }}
+    <script src="{{ .RelPermalink }}"></script>
+  {{- else }}
+    {{- with . | minify | fingerprint }}
+      <script src="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous"></script>
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const echo = document.getElementById('stage1-fp-echo');
+    const main = document.getElementById('stage1-fp');
+    if (echo && main) {
+      const observer = new MutationObserver(() => { echo.textContent = main.textContent; });
+      observer.observe(main, { childList: true, subtree: true, characterData: true });
+    }
+    document.body.addEventListener('touchmove', (e) => {
+      if (e.target === document.body) e.preventDefault();
+    }, { passive: false });
+  });
+</script>
+
+{{ end }}

--- a/layouts/escape-room/escape-room.html
+++ b/layouts/escape-room/escape-room.html
@@ -60,8 +60,9 @@
     <form id="login-form" autocomplete="off">
       <div class="login-field">
         <label for="login-email">Email Address</label>
-        <input id="login-email" type="email" placeholder="volunteer@cvcc.dev"
-               autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false" />
+        <input id="login-email" type="email"
+               autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false"
+               readonly />
       </div>
       <div class="login-field">
         <label for="login-pass">Password</label>
@@ -217,7 +218,7 @@ Awaiting secondary volunteer token...
       </div>
     </div>
 
-    <div class="stage-body" id="stage4-hint" style="white-space: pre-line;"></div>
+    <div class="stage-body" id="stage4-hint"></div>
 
     <div id="stage4-status" class="status-msg info">
       Locate Key B and plug it in, then touch it.

--- a/layouts/escape-room/escape-room.html
+++ b/layouts/escape-room/escape-room.html
@@ -14,9 +14,6 @@
 
 {{ define "main" }}
 
-<!-- HIDDEN YUBIKEY INPUT -->
-<input id="yubikey-input" type="text" autocomplete="off" autocorrect="off"
-       autocapitalize="none" spellcheck="false" aria-hidden="true" tabindex="-1" />
 
 <!-- SESSION CODE (bottom-left, for volunteer/admin reference) -->
 <div id="session-code-display">
@@ -120,6 +117,14 @@ Authenticate volunteer lead to initiate rollback.
       Plug in the correct YubiKey and touch it.
     </div>
 
+    <div class="yk-reader-wrap" id="yk-wrap-s1">
+      <div class="yk-reader-label" id="yk-label-s1">▸ TAP HERE — THEN TOUCH YUBIKEY</div>
+      <input id="yubikey-input-s1" class="yk-reader-input"
+             type="text" inputmode="none"
+             placeholder="[ KEY READER STANDBY ]"
+             autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false" />
+    </div>
+
     <div id="demo-key-a" style="display:none; margin-top:16px; padding:12px 16px; border:1px dashed var(--amber); border-radius:4px; text-align:center;">
       <div style="font-size:10px; letter-spacing:0.2em; color:var(--amber); margin-bottom:10px;">⚠ DEMO MODE — NO YUBIKEY CONNECTED</div>
       <button class="btn btn-amber" onclick="simulateKeyA()">▶ SIMULATE YUBIKEY TOUCH (KEY A)</button>
@@ -216,6 +221,14 @@ Awaiting secondary volunteer token...
 
     <div id="stage4-status" class="status-msg info">
       Locate Key B and plug it in, then touch it.
+    </div>
+
+    <div class="yk-reader-wrap" id="yk-wrap-s4">
+      <div class="yk-reader-label" id="yk-label-s4">▸ TAP HERE — THEN TOUCH YUBIKEY</div>
+      <input id="yubikey-input-s4" class="yk-reader-input"
+             type="text" inputmode="none"
+             placeholder="[ KEY READER STANDBY ]"
+             autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false" />
     </div>
 
     <div id="demo-key-b" style="display:none; margin-top:16px; padding:12px 16px; border:1px dashed var(--amber); border-radius:4px; text-align:center;">

--- a/static/escape-room/README.md
+++ b/static/escape-room/README.md
@@ -1,0 +1,201 @@
+# Project Cerberus — YubiKey Escape Room
+
+A 5-minute conference escape room experience built for developer audiences. Players trigger a simulated AI containment breach by logging in with a found password, then race to abort the sequence using hardware YubiKeys.
+
+No backend. No external dependencies. Runs as a Hugo page within the cvccSite project.
+
+---
+
+## Requirements
+
+| Item | Count | Notes |
+|---|---|---|
+| iPad (10th gen+ or Pro/Air) | 1–2 | USB-C preferred |
+| YubiKey 5 NFC or 5C | 2–4 | Need at least 2 for the final stage |
+| USB-C to USB-A adapter | 1 | If your keys are USB-A type |
+| Printed props | — | See [Props](#props) section below |
+
+---
+
+## Quick Start
+
+1. **Configure your keys** — see [YubiKey Setup](#yubikey-setup) below
+2. Edit `static/escape-room/config.js` with your key prefixes
+3. Run `hugo serve` (or deploy the site) and open `/escape-room/` in Safari on the iPad
+4. Enable Guided Access (optional but recommended for kiosk mode)
+5. Run through the game once as a staff member to verify everything works
+
+---
+
+## YubiKey Setup
+
+Each YubiKey has a unique OTP prefix — the first 12 characters of its output. You need these to tell the game which key is which.
+
+**To find a key's prefix:**
+
+1. Open any text editor on any computer (or use the Admin Panel's OTP capture tool)
+2. Click into the text field
+3. Plug in the YubiKey and touch the gold contact
+4. The key will type a 44-character string — copy the **first 12 characters**
+5. Repeat for each key
+
+**Then open `static/escape-room/config.js` and set:**
+
+```js
+KEY_A_PREFIX: "ccccccfhgnlr",  // Key A — used in Stage 1
+KEY_B_PREFIX: "ccccccelrtgt",  // Key B — used in Stage 4
+```
+
+Replace the example values with the ones you captured.
+
+---
+
+## Configuration (`static/escape-room/config.js`)
+
+All event-specific settings live in one place:
+
+| Setting | Description |
+|---|---|
+| `TIMER_SECONDS` | Game duration in seconds (default: 300 = 5 min) |
+| `LOGIN_EMAIL` / `LOGIN_PASSWORD` | Credentials on the sticky note prop |
+| `KEY_A_PREFIX` / `KEY_B_PREFIX` | First 12 chars of each YubiKey's OTP |
+| `ROSTER` | Team member names and fingerprint suffixes shown on the roster prop |
+| `ENCODED_MESSAGE` | The ROT-3 encoded string displayed in Stage 2 |
+| `CODEWORD` | The decoded answer players type in Stage 3 (default: `DELTA`) |
+| `ADMIN_PIN` | 4-digit PIN for the admin panel (default: `1337`) |
+| `WIN_QR_URL` | URL encoded into the QR code on the win screen |
+| `AUDIO_ENABLED` | Set to `false` to disable all sounds |
+
+> **Note:** If you change `CODEWORD`, update `ENCODED_MESSAGE` to match. ROT-3 shifts each letter forward by 3 positions (A→D, B→E, etc.). Example: `DELTA` encoded with ROT-3 becomes `GHOWD`.
+
+---
+
+## Running on iPad (Recommended)
+
+### Opening the game
+
+The escape room is served by Hugo as part of the cvccSite project.
+
+**Option A — Hugo dev server (local, for testing)**
+1. On a laptop connected to the same Wi-Fi, run:
+   ```bash
+   hugo serve --bind 0.0.0.0
+   ```
+2. On the iPad, open Safari and navigate to `http://<your-laptop-ip>:1313/escape-room/`
+
+**Option B — Deployed site**
+1. Deploy the Hugo site as normal (`hugo` → publish `public/`)
+2. On the iPad, navigate to `https://yoursite.com/escape-room/`
+
+### Kiosk mode (Guided Access)
+
+To prevent players from accidentally leaving the app:
+
+1. Go to **Settings → Accessibility → Guided Access** and turn it on
+2. Open Safari with `/escape-room/` loaded
+3. Triple-click the side button to start Guided Access
+4. Tap **Start** — the iPad is now locked to that screen
+5. Triple-click again and enter your passcode to exit
+
+---
+
+## Admin Panel (`/escape-room/admin/`)
+
+Open `/escape-room/admin/` in a browser (separately from the game) for event management.
+
+- **PIN-gated** — enter the 4-digit `ADMIN_PIN` from `config.js`
+- **OTP Capture** — click the input box, touch a YubiKey, and the prefix is extracted automatically
+- **Config display** — shows current key prefixes, codeword, and timer duration loaded from `config.js`
+- **Reset button** — redirects to `/escape-room/` (use between groups)
+
+---
+
+## Game Flow
+
+```
+INTRO → Stage 0 (login with sticky note creds — triggers lockdown)
+      → Stage 1 (find correct key on roster, plug in Key A)
+      → Stage 2 (decode ROT-3 cipher using the cipher wheel prop)
+      → Stage 3 (type the 5-letter codeword)
+      → Stage 4 (find hidden Key B, plug in for dual auth)
+      → WIN or FAIL (if timer expires)
+```
+
+**Timer:** Starts the moment lockdown triggers (after Stage 0 login). The HUD counts down with color warnings — amber at 90 seconds, red at 30 seconds.
+
+---
+
+## Props
+
+Print and laminate these before the event:
+
+| Prop | Content | Used In |
+|---|---|---|
+| **Sticky note** | `m.reeves@cerberus.io` / `Summer2024!` (or whatever is in `config.js`) | Stage 0 |
+| **Team Roster card** | 4 names, departments, and key fingerprint suffixes from `config.js` | Stage 1 |
+| **ROT-3 Cipher Wheel** | Alphabet with +3 shift — A=D, B=E, C=F, etc. | Stage 2 |
+| **YubiKey labels** | Small sticker on each key with the team member's name | Stage 1 |
+| **"Authorized Personnel Only" sign** | Flavor/immersion | Desk dressing |
+
+**For the Team Roster card**, the fingerprint suffixes to print are the last 4 characters of each prefix defined in `config.js → ROSTER`. The target key (M. Reeves) should match the terminal display in Stage 1.
+
+**Hiding Key B** (Stage 4 options):
+- Taped under the table
+- Inside a small combination lockbox
+- In a sealed envelope labeled "BREAK ONLY IN EMERGENCY"
+
+---
+
+## Sounds (Optional)
+
+Drop the following MP3 files into `static/escape-room/sounds/` to enable audio:
+
+| File | Used For |
+|---|---|
+| `beep.mp3` | Button presses, successful key auth |
+| `alarm.mp3` | Lockdown trigger, fail screen |
+| `success.mp3` | Win screen |
+
+If files are missing, the game runs silently. Audio can also be globally disabled with `AUDIO_ENABLED: false` in `config.js`.
+
+Free sources: [freesound.org](https://freesound.org), [mixkit.co](https://mixkit.co/free-sound-effects/), [zapsplat.com](https://www.zapsplat.com)
+
+---
+
+## Reset Between Groups
+
+1. Tap **Reset** in the admin panel (or navigate to `/escape-room/`)
+2. Retrieve Key B from its hiding spot and re-hide it
+3. Reposition any moved props
+4. Ready in ~60 seconds
+
+---
+
+## Difficulty Tuning
+
+| Setting | Easier | Harder |
+|---|---|---|
+| Timer | 7 min (`420`) | 4 min (`240`) |
+| Cipher | ROT-3 with a cheat sheet | Remove the cipher wheel |
+| Key B hiding spot | In plain sight, labeled | Locked box with combination clue |
+| Keys required | 2 keys | Add a third prefix and stage |
+
+---
+
+## Troubleshooting
+
+**YubiKey isn't being detected**
+- Make sure the hidden input is focused — tap anywhere on an active key-auth screen to refocus
+- Verify the prefix in `config.js` matches the key by capturing it fresh in the admin panel
+- Check that the key is fully inserted and you're touching the gold contact (not just resting your finger)
+
+**Login form isn't accepting credentials**
+- Double-check `LOGIN_EMAIL` and `LOGIN_PASSWORD` in `config.js` — values are case-sensitive
+- Confirm the sticky note prop matches exactly what's in the config
+
+**Audio not playing**
+- iOS requires a user interaction before playing audio — this is handled, but if sounds are missing the game continues silently
+- Make sure MP3 files are present in `static/escape-room/sounds/` and `AUDIO_ENABLED` is `true`
+
+**Timer is wrong**
+- `TIMER_SECONDS` in `config.js` is in seconds — `300` = 5 minutes, `420` = 7 minutes

--- a/static/escape-room/config.js
+++ b/static/escape-room/config.js
@@ -1,0 +1,64 @@
+// ============================================================
+// CERBERUS ESCAPE ROOM — CONFIG
+// Edit before each event. Do NOT share publicly.
+// ============================================================
+
+const CONFIG = {
+  // ---- Timer ------------------------------------------------
+  TIMER_SECONDS: 300, // 5 minutes (300 seconds)
+
+  // ---- Stage 0 login credentials ---------------------------
+  // One set is chosen at random each time the game loads.
+  // Each object: { name, email, password }
+  LOGIN_CREDENTIALS: [
+    { name: "A. Wright", email: "a.wright@cvcc.dev",  password: "CodeCamp2026!" },
+    { name: "J. Torres", email: "j.torres@cvcc.dev",  password: "Volunteer#1"   },
+    { name: "S. Kim",    email: "s.kim@cvcc.dev",     password: "AppDev2026"    },
+    { name: "R. Patel",  email: "r.patel@cvcc.dev",   password: "AVTech#99"     },
+  ],
+
+  // ---- Stage 1: YubiKey prefixes ---------------------------
+  // First 12 chars of OTP output identify which physical key was used.
+  // To find these: open a text editor, plug in the key, touch it,
+  // copy the first 12 characters of the output.
+  KEY_A_PREFIX: "ccccccfhgnlr", // Key A — primary / stage 1
+  KEY_B_PREFIX: "ccccccelrtgt", // Key B — secondary / stage 4
+
+  // ---- Stage 1: Team roster (displayed on physical prop) ---
+  // 'suffix' is the last 4 chars shown on the roster card.
+  // The app matches on the full prefix above; this is just for
+  // generating the prop printout reference.
+  ROSTER: [
+    { name: "A. Wright",  dept: "Site Reliability", keySuffix: "gnlr", isTarget: true  },
+    { name: "J. Torres",  dept: "Web Volunteer",    keySuffix: "rt7x", isTarget: false },
+    { name: "S. Kim",     dept: "App Dev",          keySuffix: "2mk9", isTarget: false },
+    { name: "R. Patel",   dept: "AV & Networking",  keySuffix: "9cbe", isTarget: false },
+  ],
+
+  // ---- Stage 2: Cipher ------------------------------------
+  // Encoded string displayed on screen. ROT-3 (Caesar +3).
+  // "THE CODE IS: DELTA" → encoded with ROT-3 → "WKH FRGH LV: GHOWD"
+  ENCODED_MESSAGE: "WKH FRGH LV: GHOWD",
+  CODEWORD: "DELTA", // Players decode and type this in Stage 3
+
+  // ---- Stage 4: Second key hint ---------------------------
+  // Shown as a clue on screen after stage 3 passes.
+  KEY_B_HINT: "Locate the secondary authentication device.\nCheck the volunteer station for the backup hardware key.",
+
+  // ---- Admin panel PIN ------------------------------------
+  ADMIN_PIN: "1337",
+
+  // ---- Win screen QR URL ----------------------------------
+  // Replace with actual Yubico landing page or giveaway URL
+  WIN_QR_URL: "https://www.yubico.com",
+
+  // ---- Audio (set false to disable) -----------------------
+  AUDIO_ENABLED: true,
+
+  // ---- Demo mode ------------------------------------------
+  // Set to false when no physical YubiKeys are available.
+  // Adds a visible "Simulate YubiKey Touch" button on stages 1 and 4
+  // so the game can be run and tested without hardware.
+  // Set back to true before any real event.
+  YUBIKEY_REQUIRED: false,
+};

--- a/static/escape-room/config.js
+++ b/static/escape-room/config.js
@@ -18,9 +18,9 @@ const CONFIG = {
   KEY_B_USER_ID: "CVCC2026-45",
 
   ROSTER: [
-    { id: "CVCC2026-61", firstName: "Tommy",    lastName: "Luangrath", name: "Tommy Luangrath",  dept: "Check-in Volunteer",    email: "t.luangrath@cvcc.dev", password: "dontlayafinger", keyPrefix: "ccccccfhgnlg", keySuffix: "CVCC2026-61", favoriteColor: "Yellow", favoriteSweet: "Butterfinger" },
-    { id: "CVCC2026-21", firstName: "Mitchell", lastName: "Weston",    name: "Mitchell Weston",  dept: "Sponsor Coordinator",   email: "m.weston@cvcc.dev",    password: "password123",    keyPrefix: "ccccccfhgngl", keySuffix: "CVCC2026-21", favoriteColor: "Red",    favoriteSweet: "PayDay"       },
-    { id: "CVCC2026-45", firstName: "Jessica",  lastName: "Torres",    name: "Jessica Torres",   dept: "Organizer",             email: "j.torres@cvcc.dev",    password: "Volunteer#1",    keyPrefix: "ccccccelrtgt", keySuffix: "CVCC2026-45", favoriteColor: "Blue",   favoriteSweet: "Left Twix"    },
+    { id: "CVCC2026-61", firstName: "Tommy",    lastName: "Luangrath", name: "Tommy Luangrath",  dept: "Check-in Volunteer",    email: "t.luangrath@cvcc.dev", password: "dontlayafinger", keyPrefix: "cccccdbhntlg", keySuffix: "CVCC2026-61", favoriteColor: "Yellow", favoriteSweet: "Butterfinger" },
+    { id: "CVCC2026-21", firstName: "Mitchell", lastName: "Weston",    name: "Mitchell Weston",  dept: "Sponsor Coordinator",   email: "m.weston@cvcc.dev",    password: "password123",    keyPrefix: "cccccdbhntgl", keySuffix: "CVCC2026-21", favoriteColor: "Red",    favoriteSweet: "PayDay"       },
+    { id: "CVCC2026-45", firstName: "Jessica",  lastName: "Torres",    name: "Jessica Torres",   dept: "Organizer",             email: "j.torres@cvcc.dev",    password: "Volunteer#1",    keyPrefix: "cccccdbhnrld", keySuffix: "CVCC2026-45", favoriteColor: "Blue",   favoriteSweet: "Left Twix"    },
     { id: "CVCC2026-87", firstName: "Dan",      lastName: "Bunmander", name: "Dan Bunmander",    dept: "Activities Specialist", email: "d.bunmander@cvcc.dev", password: "cake4me",        keyPrefix: "cccccdbhnrnc", keySuffix: "CVCC2026-87", favoriteColor: "White",  favoriteSweet: "Cake"         },
   ],
 
@@ -29,10 +29,6 @@ const CONFIG = {
   // "THE CODE IS: DELTA" → encoded with ROT-3 → "WKH FRGH LV: GHOWD"
   ENCODED_MESSAGE: "WKH FRGH LV: GHOWD",
   CODEWORD: "DELTA", // Players decode and type this in Stage 3
-
-  // ---- Stage 4: Second key hint ---------------------------
-  // Shown as a clue on screen after stage 3 passes.
-  KEY_B_HINT: "Locate the secondary authentication device.\nCheck the volunteer station for the backup hardware key.",
 
   // ---- Admin panel PIN ------------------------------------
   ADMIN_PIN: "1337",
@@ -49,7 +45,7 @@ const CONFIG = {
   // Adds a visible "Simulate YubiKey Touch" button on stages 1 and 4
   // so the game can be run and tested without hardware.
   // Set back to true before any real event.
-  YUBIKEY_REQUIRED: false,
+  YUBIKEY_REQUIRED: true,
 
   // ---- Stage toggles --------------------------------------
   // Set any stage to false to skip it entirely during play.

--- a/static/escape-room/config.js
+++ b/static/escape-room/config.js
@@ -7,32 +7,21 @@ const CONFIG = {
   // ---- Timer ------------------------------------------------
   TIMER_SECONDS: 300, // 5 minutes (300 seconds)
 
-  // ---- Stage 0 login credentials ---------------------------
-  // One set is chosen at random each time the game loads.
-  // Each object: { name, email, password }
-  LOGIN_CREDENTIALS: [
-    { name: "A. Wright", email: "a.wright@cvcc.dev",  password: "CodeCamp2026!" },
-    { name: "J. Torres", email: "j.torres@cvcc.dev",  password: "Volunteer#1"   },
-    { name: "S. Kim",    email: "s.kim@cvcc.dev",     password: "AppDev2026"    },
-    { name: "R. Patel",  email: "r.patel@cvcc.dev",   password: "AVTech#99"     },
-  ],
+  // ---- Roster -----------------------------------------------
+  // Single source of truth for all users.
+  // email + password: used for Stage 0 login (one user chosen at random each game).
+  // keyPrefix: first 12 chars of the YubiKey OTP — use Live OTP Capture in admin.
+  //   Leave blank ("") until a key is assigned; blanks are excluded from play.
+  // keySuffix: shown on the physical roster prop card.
+  // KEY_B_USER_ID: always used for Stage 4 (dual auth). Excluded from Stage 0/1 pool.
+  //   All other users with a keyPrefix are eligible for Stage 0 login + Stage 1 key.
+  KEY_B_USER_ID: "CVCC2026-45",
 
-  // ---- Stage 1: YubiKey prefixes ---------------------------
-  // First 12 chars of OTP output identify which physical key was used.
-  // To find these: open a text editor, plug in the key, touch it,
-  // copy the first 12 characters of the output.
-  KEY_A_PREFIX: "ccccccfhgnlr", // Key A — primary / stage 1
-  KEY_B_PREFIX: "ccccccelrtgt", // Key B — secondary / stage 4
-
-  // ---- Stage 1: Team roster (displayed on physical prop) ---
-  // 'suffix' is the last 4 chars shown on the roster card.
-  // The app matches on the full prefix above; this is just for
-  // generating the prop printout reference.
   ROSTER: [
-    { name: "A. Wright",  dept: "Site Reliability", keySuffix: "gnlr", isTarget: true  },
-    { name: "J. Torres",  dept: "Web Volunteer",    keySuffix: "rt7x", isTarget: false },
-    { name: "S. Kim",     dept: "App Dev",          keySuffix: "2mk9", isTarget: false },
-    { name: "R. Patel",   dept: "AV & Networking",  keySuffix: "9cbe", isTarget: false },
+    { id: "CVCC2026-61", firstName: "Tommy",    lastName: "Luangrath", name: "Tommy Luangrath",  dept: "Check-in Volunteer",    email: "t.luangrath@cvcc.dev", password: "dontlayafinger", keyPrefix: "ccccccfhgnlg", keySuffix: "CVCC2026-61", favoriteColor: "Yellow", favoriteSweet: "Butterfinger" },
+    { id: "CVCC2026-21", firstName: "Mitchell", lastName: "Weston",    name: "Mitchell Weston",  dept: "Sponsor Coordinator",   email: "m.weston@cvcc.dev",    password: "password123",    keyPrefix: "ccccccfhgngl", keySuffix: "CVCC2026-21", favoriteColor: "Red",    favoriteSweet: "PayDay"       },
+    { id: "CVCC2026-45", firstName: "Jessica",  lastName: "Torres",    name: "Jessica Torres",   dept: "Organizer",             email: "j.torres@cvcc.dev",    password: "Volunteer#1",    keyPrefix: "ccccccelrtgt", keySuffix: "CVCC2026-45", favoriteColor: "Blue",   favoriteSweet: "Left Twix"    },
+    { id: "CVCC2026-87", firstName: "Dan",      lastName: "Bunmander", name: "Dan Bunmander",    dept: "Activities Specialist", email: "d.bunmander@cvcc.dev", password: "cake4me",        keyPrefix: "cccccdbhnrnc", keySuffix: "CVCC2026-87", favoriteColor: "White",  favoriteSweet: "Cake"         },
   ],
 
   // ---- Stage 2: Cipher ------------------------------------
@@ -61,4 +50,16 @@ const CONFIG = {
   // so the game can be run and tested without hardware.
   // Set back to true before any real event.
   YUBIKEY_REQUIRED: false,
+
+  // ---- Stage toggles --------------------------------------
+  // Set any stage to false to skip it entirely during play.
+  // Can also be changed live from the admin panel (stored in localStorage,
+  // which takes precedence over these defaults).
+  STAGES_ENABLED: {
+    s0: true, // Stage 0 — Login
+    s1: true, // Stage 1 — Identify committer (Key A)
+    s2: false, // Stage 2 — Decrypt cipher
+    s3: false, // Stage 3 — Enter codeword
+    s4: true, // Stage 4 — Dual auth (Key B)
+  },
 };

--- a/static/escape-room/sounds/README.txt
+++ b/static/escape-room/sounds/README.txt
@@ -1,0 +1,14 @@
+SOUNDS DIRECTORY
+================
+
+Place the following audio files here:
+
+  beep.mp3     — Short UI confirmation beep (used on button presses, key accepted, etc.)
+  success.mp3  — Victory fanfare (played on win screen)
+  alarm.mp3    — Alert/klaxon sound (played when lockdown triggers and on fail screen)
+
+These are optional. If the files are missing, the game continues silently.
+Audio can be globally disabled by setting AUDIO_ENABLED: false in config.js.
+
+Recommended formats: MP3 for broadest browser support.
+Keep files small (< 200 KB each) for fast loading.


### PR DESCRIPTION
This Pull request is not ready for merge so it'll be left in draft for the time being. I wanted to provide people a place they can add feedback early on the work if they choose. I received the Yubikey's at last night's meeting so the escape-room has not been tested with physical yubikeys. In the config.js there is a flag to test the game flow without a physical yubikey: `YUBIKEY_REQUIRED: false,`

This pull request adds a yubikey demo in the form of an escape room puzzle. 

## Game Flow

```
INTRO → Stage 0 (login with sticky note creds — triggers lockdown)
Timer Starts → Stage 1 (find correct key on roster, plug in Key A)
      → Stage 2 (decode ROT-3 cipher using the cipher wheel prop) (
      → Stage 3 (type the 5-letter codeword)
      → Stage 4 (find hidden Key B, plug in for dual auth)
      → WIN or FAIL (if timer expires)
```

Both the escape-room and admin pages are empty shells so we can override the default layout with a custom layout. 

Remaining tasks:
- [ ] Confirm everything works with physical 
- [ ] Adjust Stage 2 & 3 to use physical Davinci Cipher. 
- [ ] Create physical props
- [ ] Create a `10 things you can lock down today` handout
- [ ] Lock admin page with yubikey
- [ ] (optional and likely after the code camp) Add feature to play this digitally so we can include this in a blog post. 